### PR TITLE
Add support for experimental parallel texture uploads to iced_wgpu's image pipeline

### DIFF
--- a/wgpu/Cargo.toml
+++ b/wgpu/Cargo.toml
@@ -27,6 +27,7 @@ webgl = ["wgpu/webgl"]
 [dependencies]
 iced_graphics.workspace = true
 
+image.workspace = true # image crate
 bitflags.workspace = true
 bytemuck.workspace = true
 futures.workspace = true

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -5,6 +5,8 @@ use crate::quad;
 use crate::text;
 use crate::triangle;
 
+pub const DEFAULT_ATLAS_SIZE: u32 = 2048;
+
 #[derive(Debug, Clone)]
 pub struct ImageConfig {
     pub use_parallel_processing: bool,
@@ -15,7 +17,7 @@ impl Default for ImageConfig {
     fn default() -> Self {
         Self {
             use_parallel_processing: true,
-            atlas_size: crate::image::atlas::DEFAULT_SIZE,
+            atlas_size: DEFAULT_ATLAS_SIZE,
         }
     }
 }

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -5,7 +5,6 @@ use crate::quad;
 use crate::text;
 use crate::triangle;
 
-pub const DEFAULT_ATLAS_SIZE: u32 = 2048;
 
 #[derive(Debug, Clone)]
 pub struct ImageConfig {
@@ -13,11 +12,12 @@ pub struct ImageConfig {
     pub atlas_size: u32,
 }
 
+#[cfg(feature = "image")]
 impl Default for ImageConfig {
     fn default() -> Self {
         Self {
             use_parallel_processing: true,
-            atlas_size: DEFAULT_ATLAS_SIZE,
+            atlas_size: crate::image::atlas::DEFAULT_SIZE,
         }
     }
 }

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -5,6 +5,19 @@ use crate::quad;
 use crate::text;
 use crate::triangle;
 
+#[derive(Debug, Clone)]
+pub struct ImageConfig {
+    pub use_parallel_processing: bool,
+}
+
+impl Default for ImageConfig {
+    fn default() -> Self {
+        Self {
+            use_parallel_processing: true,
+        }
+    }
+}
+
 #[allow(missing_debug_implementations)]
 pub struct Engine {
     pub(crate) staging_belt: wgpu::util::StagingBelt,
@@ -15,6 +28,8 @@ pub struct Engine {
     pub(crate) triangle_pipeline: triangle::Pipeline,
     #[cfg(any(feature = "image", feature = "svg"))]
     pub(crate) image_pipeline: crate::image::Pipeline,
+    #[cfg(any(feature = "image", feature = "svg"))]
+    pub(crate) image_config: ImageConfig,
     pub(crate) primitive_storage: primitive::Storage,
 }
 
@@ -24,7 +39,8 @@ impl Engine {
         device: &wgpu::Device,
         queue: &wgpu::Queue,
         format: wgpu::TextureFormat,
-        antialiasing: Option<Antialiasing>, // TODO: Initialize AA pipelines lazily
+        antialiasing: Option<Antialiasing>,
+        image_config: Option<ImageConfig>,
     ) -> Self {
         let backend = _adapter.get_info().backend;
         println!("Using GPU backend: {:?}", backend);
@@ -57,6 +73,9 @@ impl Engine {
 
             #[cfg(any(feature = "image", feature = "svg"))]
             image_pipeline,
+            
+            #[cfg(any(feature = "image", feature = "svg"))]
+            image_config: image_config.unwrap_or_default(),
 
             primitive_storage: primitive::Storage::default(),
         }
@@ -67,7 +86,9 @@ impl Engine {
         &self,
         device: &wgpu::Device,
     ) -> crate::image::Cache {
-        self.image_pipeline.create_cache(device)
+        let mut cache = self.image_pipeline.create_cache(device);
+        cache.set_parallel_processing(self.image_config.use_parallel_processing);
+        cache
     }
 
     pub fn submit(

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -26,6 +26,9 @@ impl Engine {
         format: wgpu::TextureFormat,
         antialiasing: Option<Antialiasing>, // TODO: Initialize AA pipelines lazily
     ) -> Self {
+        let backend = _adapter.get_info().backend;
+        println!("Using GPU backend: {:?}", backend);
+        
         let text_pipeline = text::Pipeline::new(device, queue, format);
         let quad_pipeline = quad::Pipeline::new(device, format);
         let triangle_pipeline =
@@ -39,11 +42,12 @@ impl Engine {
         };
 
         Self {
-            // TODO: Resize belt smartly (?)
-            // It would be great if the `StagingBelt` API exposed methods
-            // for introspection to detect when a resize may be worth it.
             staging_belt: wgpu::util::StagingBelt::new(
-                buffer::MAX_WRITE_SIZE as u64,
+                if cfg!(target_os = "linux") {
+                    buffer::MAX_WRITE_SIZE as u64 * 4 // Larger for Linux
+                } else {
+                    buffer::MAX_WRITE_SIZE as u64     // Normal size for other platforms
+                }
             ),
             format,
 

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -75,6 +75,8 @@ impl Engine {
         queue: &wgpu::Queue,
         encoder: wgpu::CommandEncoder,
     ) -> wgpu::SubmissionIndex {
+        let render_start = std::time::Instant::now();
+        
         self.staging_belt.finish();
         let index = queue.submit(Some(encoder.finish()));
         self.staging_belt.recall();
@@ -84,7 +86,15 @@ impl Engine {
         self.triangle_pipeline.end_frame();
 
         #[cfg(any(feature = "image", feature = "svg"))]
-        self.image_pipeline.end_frame();
+        {
+            // Record render time
+            let render_duration = render_start.elapsed();
+            if render_duration.as_millis() > 30 {
+                println!("SLOW GPU SUBMIT: {:.2}ms", render_duration.as_secs_f64() * 1000.0);
+            }
+            crate::image::record_image_render_duration(render_duration);
+            self.image_pipeline.end_frame();
+        }
 
         index
     }

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -8,12 +8,14 @@ use crate::triangle;
 #[derive(Debug, Clone)]
 pub struct ImageConfig {
     pub use_parallel_processing: bool,
+    pub atlas_size: u32,
 }
 
 impl Default for ImageConfig {
     fn default() -> Self {
         Self {
             use_parallel_processing: true,
+            atlas_size: crate::image::atlas::DEFAULT_SIZE,
         }
     }
 }
@@ -86,7 +88,7 @@ impl Engine {
         &self,
         device: &wgpu::Device,
     ) -> crate::image::Cache {
-        let mut cache = self.image_pipeline.create_cache(device);
+        let mut cache = self.image_pipeline.create_cache(device, self.image_config.atlas_size);
         cache.set_parallel_processing(self.image_config.use_parallel_processing);
         cache
     }

--- a/wgpu/src/engine.rs
+++ b/wgpu/src/engine.rs
@@ -38,6 +38,7 @@ pub struct Engine {
 }
 
 impl Engine {
+    #[allow(unused_variables)]
     pub fn new(
         _adapter: &wgpu::Adapter,
         device: &wgpu::Device,
@@ -100,6 +101,7 @@ impl Engine {
         queue: &wgpu::Queue,
         encoder: wgpu::CommandEncoder,
     ) -> wgpu::SubmissionIndex {
+        #[cfg(any(feature = "image", feature = "svg"))]
         let render_start = std::time::Instant::now();
         
         self.staging_belt.finish();

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -316,8 +316,8 @@ impl Atlas {
     pub fn upload_allocation(
         &mut self,
         data: &[u8],
-        width: u32,
-        height: u32,
+        image_width: u32,
+        image_height: u32,
         padding: u32,
         offset: usize,
         allocation: &Allocation,
@@ -356,8 +356,8 @@ impl Atlas {
                 buffer: &buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: offset as u64,
-                    bytes_per_row: Some(4 * width + padding),
-                    rows_per_image: Some(height),
+                    bytes_per_row: Some(4 * image_width + padding),
+                    rows_per_image: Some(image_height),
                 },
             },
             wgpu::ImageCopyTexture {
@@ -462,58 +462,20 @@ impl Atlas {
                 }],
             });
     }
-
-    // Get fragmentation metrics
-    pub fn get_fragmentation_stats(&self) -> (usize, usize, f32) {
-        let total_allocations = self.layers.len();
-        let fragmented_count = self.layers.iter()
-            .filter(|layer| matches!(layer, Layer::Busy(_)))
-            .count();
-        
-        let fragmentation_ratio = if total_allocations > 0 {
-            fragmented_count as f32 / total_allocations as f32
-        } else {
-            0.0
-        };
-        
-        (total_allocations, fragmented_count, fragmentation_ratio)
-    }
-
-    // Add method to get allocation from an entry
-    pub fn allocate_entry(
-        &mut self,
-        device: &wgpu::Device,
-        extent: wgpu::Extent3d,
-    ) -> Option<Entry> {
-        let width = extent.width;
-        let height = extent.height;
-        
-        let current_size = self.layers.len();
-        let entry = self.allocate(width, height)?;
-
-        // We grow the internal texture after allocating if necessary
-        let new_layers = self.layers.len() - current_size;
-        
-        if new_layers > 0 {
-            log::debug!("Growing atlas by {} layers", new_layers);
-        }
-        
-        Some(entry)
-    }
     
-    // Separate the grow operation from allocation
+    // Add new method to grow if needed
     pub fn grow_if_needed(
         &mut self,
-        new_layers: usize,
+        amount: usize,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
     ) {
-        if new_layers > 0 {
-            self.grow(new_layers, device, encoder);
+        if amount > 0 {
+            self.grow(amount, device, encoder);
         }
     }
 
-    // Add this method to check if an allocation is valid
+    // Add new method to check if an allocation is valid
     pub fn is_allocation_valid(&self, allocation: &Allocation) -> bool {
         allocation.layer() < self.layer_count()
     }

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -10,7 +10,8 @@ pub use layer::Layer;
 
 use allocator::Allocator;
 
-pub const SIZE: u32 = 2048;
+//pub const SIZE: u32 = 2048;
+pub const SIZE: u32 = 4096;
 
 use crate::core::Size;
 use crate::graphics::color;

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -313,7 +313,7 @@ impl Atlas {
         }
     }
 
-    fn upload_allocation(
+    pub fn upload_allocation(
         &mut self,
         data: &[u8],
         image_width: u32,
@@ -469,5 +469,39 @@ impl Atlas {
         };
         
         (total_allocations, fragmented_count, fragmentation_ratio)
+    }
+
+    // Add method to get allocation from an entry
+    pub fn allocate_entry(
+        &mut self,
+        device: &wgpu::Device,
+        extent: wgpu::Extent3d,
+    ) -> Option<Entry> {
+        let width = extent.width;
+        let height = extent.height;
+        
+        let current_size = self.layers.len();
+        let entry = self.allocate(width, height)?;
+
+        // We grow the internal texture after allocating if necessary
+        let new_layers = self.layers.len() - current_size;
+        
+        if new_layers > 0 {
+            log::debug!("Growing atlas by {} layers", new_layers);
+        }
+        
+        Some(entry)
+    }
+    
+    // Separate the grow operation from allocation
+    pub fn grow_if_needed(
+        &mut self,
+        new_layers: usize,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        if new_layers > 0 {
+            self.grow(new_layers, device, encoder);
+        }
     }
 }

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -454,4 +454,20 @@ impl Atlas {
                 }],
             });
     }
+
+    // Get fragmentation metrics
+    pub fn get_fragmentation_stats(&self) -> (usize, usize, f32) {
+        let total_allocations = self.layers.len();
+        let fragmented_count = self.layers.iter()
+            .filter(|layer| matches!(layer, Layer::Busy(_)))
+            .count();
+        
+        let fragmentation_ratio = if total_allocations > 0 {
+            fragmented_count as f32 / total_allocations as f32
+        } else {
+            0.0
+        };
+        
+        (total_allocations, fragmented_count, fragmentation_ratio)
+    }
 }

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -10,7 +10,7 @@ pub use layer::Layer;
 
 use allocator::Allocator;
 
-//pub const SIZE: u32 = 2048;
+pub const DEFAULT_SIZE: u32 = 2048;
 
 use crate::core::Size;
 use crate::graphics::color;

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -194,7 +194,7 @@ impl Atlas {
         }
     }
 
-    fn allocate(&mut self, width: u32, height: u32) -> Option<Entry> {
+    pub fn allocate(&mut self, width: u32, height: u32) -> Option<Entry> {
         // Allocate one layer if texture fits perfectly
         if width == SIZE && height == SIZE {
             let mut empty_layers = self

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -479,4 +479,9 @@ impl Atlas {
     pub fn is_allocation_valid(&self, allocation: &Allocation) -> bool {
         allocation.layer() < self.layer_count()
     }
+
+    // Add this method to get the texture directly
+    pub fn texture(&self) -> &wgpu::Texture {
+        &self.texture
+    }
 }

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -11,7 +11,7 @@ pub use layer::Layer;
 use allocator::Allocator;
 
 //pub const SIZE: u32 = 2048;
-pub const SIZE: u32 = 4096;
+pub const DEFAULT_SIZE: u32 = 4096;
 
 use crate::core::Size;
 use crate::graphics::color;
@@ -25,6 +25,7 @@ pub struct Atlas {
     texture_bind_group: wgpu::BindGroup,
     texture_layout: Arc<wgpu::BindGroupLayout>,
     layers: Vec<Layer>,
+    size: u32,
 }
 
 impl Atlas {
@@ -32,7 +33,10 @@ impl Atlas {
         device: &wgpu::Device,
         backend: wgpu::Backend,
         texture_layout: Arc<wgpu::BindGroupLayout>,
+        size: u32,
     ) -> Self {
+        let size = if size == 0 { DEFAULT_SIZE } else { size };
+        
         let layers = match backend {
             // On the GL backend we start with 2 layers, to help wgpu figure
             // out that this texture is `GL_TEXTURE_2D_ARRAY` rather than `GL_TEXTURE_2D`
@@ -42,8 +46,8 @@ impl Atlas {
         };
 
         let extent = wgpu::Extent3d {
-            width: SIZE,
-            height: SIZE,
+            width: size,
+            height: size,
             depth_or_array_layers: layers.len() as u32,
         };
 
@@ -85,6 +89,7 @@ impl Atlas {
             texture_bind_group,
             texture_layout,
             layers,
+            size,
         }
     }
 
@@ -197,7 +202,7 @@ impl Atlas {
 
     pub fn allocate(&mut self, width: u32, height: u32) -> Option<Entry> {
         // Allocate one layer if texture fits perfectly
-        if width == SIZE && height == SIZE {
+        if width == self.size && height == self.size {
             let mut empty_layers = self
                 .layers
                 .iter_mut()
@@ -218,16 +223,16 @@ impl Atlas {
         }
 
         // Split big textures across multiple layers
-        if width > SIZE || height > SIZE {
+        if width > self.size || height > self.size {
             let mut fragments = Vec::new();
             let mut y = 0;
 
             while y < height {
-                let height = std::cmp::min(height - y, SIZE);
+                let height = std::cmp::min(height - y, self.size);
                 let mut x = 0;
 
                 while x < width {
-                    let width = std::cmp::min(width - x, SIZE);
+                    let width = std::cmp::min(width - x, self.size);
 
                     let allocation = self.allocate(width, height)?;
 
@@ -254,7 +259,7 @@ impl Atlas {
         for (i, layer) in self.layers.iter_mut().enumerate() {
             match layer {
                 Layer::Empty => {
-                    let mut allocator = Allocator::new(SIZE);
+                    let mut allocator = Allocator::new(self.size);
 
                     if let Some(region) = allocator.allocate(width, height) {
                         *layer = Layer::Busy(allocator);
@@ -278,7 +283,7 @@ impl Atlas {
         }
 
         // Create new layer with atlas allocator
-        let mut allocator = Allocator::new(SIZE);
+        let mut allocator = Allocator::new(self.size);
 
         if let Some(region) = allocator.allocate(width, height) {
             self.layers.push(Layer::Busy(allocator));
@@ -336,7 +341,8 @@ impl Atlas {
         use wgpu::util::DeviceExt;
 
         let (x, y) = allocation.position();
-        let Size { width, height } = allocation.size();
+        //let Size { width, height } = allocation.size();
+        let Size { width, height } = allocation.size(self.size);
         let layer = allocation.layer();
 
         let extent = wgpu::Extent3d {
@@ -388,8 +394,8 @@ impl Atlas {
         let new_texture = device.create_texture(&wgpu::TextureDescriptor {
             label: Some("iced_wgpu::image texture atlas"),
             size: wgpu::Extent3d {
-                width: SIZE,
-                height: SIZE,
+                width: self.size,
+                height: self.size,
                 depth_or_array_layers: self.layers.len() as u32,
             },
             mip_level_count: 1,
@@ -437,8 +443,8 @@ impl Atlas {
                     aspect: wgpu::TextureAspect::default(),
                 },
                 wgpu::Extent3d {
-                    width: SIZE,
-                    height: SIZE,
+                    width: self.size,
+                    height: self.size,
                     depth_or_array_layers: 1,
                 },
             );
@@ -479,5 +485,9 @@ impl Atlas {
     // Add this method to get the texture directly
     pub fn texture(&self) -> &wgpu::Texture {
         &self.texture
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
     }
 }

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -11,7 +11,6 @@ pub use layer::Layer;
 use allocator::Allocator;
 
 //pub const SIZE: u32 = 2048;
-pub const DEFAULT_SIZE: u32 = 4096;
 
 use crate::core::Size;
 use crate::graphics::color;

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -476,11 +476,6 @@ impl Atlas {
         }
     }
 
-    // Add new method to check if an allocation is valid
-    pub fn is_allocation_valid(&self, allocation: &Allocation) -> bool {
-        allocation.layer() < self.layer_count()
-    }
-
     // Add this method to get the texture directly
     pub fn texture(&self) -> &wgpu::Texture {
         &self.texture

--- a/wgpu/src/image/atlas.rs
+++ b/wgpu/src/image/atlas.rs
@@ -316,14 +316,22 @@ impl Atlas {
     pub fn upload_allocation(
         &mut self,
         data: &[u8],
-        image_width: u32,
-        image_height: u32,
+        width: u32,
+        height: u32,
         padding: u32,
         offset: usize,
         allocation: &Allocation,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
     ) {
+        // Safety check - ensure the layer exists before uploading
+        let layer = allocation.layer();
+        if layer >= self.layer_count() {
+            log::error!("Cannot upload to layer {} - atlas has only {} layers", 
+                      layer, self.layer_count());
+            return;
+        }
+        
         use wgpu::util::DeviceExt;
 
         let (x, y) = allocation.position();
@@ -348,8 +356,8 @@ impl Atlas {
                 buffer: &buffer,
                 layout: wgpu::ImageDataLayout {
                     offset: offset as u64,
-                    bytes_per_row: Some(4 * image_width + padding),
-                    rows_per_image: Some(image_height),
+                    bytes_per_row: Some(4 * width + padding),
+                    rows_per_image: Some(height),
                 },
             },
             wgpu::ImageCopyTexture {
@@ -503,5 +511,10 @@ impl Atlas {
         if new_layers > 0 {
             self.grow(new_layers, device, encoder);
         }
+    }
+
+    // Add this method to check if an allocation is valid
+    pub fn is_allocation_valid(&self, allocation: &Allocation) -> bool {
+        allocation.layer() < self.layer_count()
     }
 }

--- a/wgpu/src/image/atlas/allocation.rs
+++ b/wgpu/src/image/atlas/allocation.rs
@@ -1,7 +1,7 @@
 use crate::core::Size;
 use crate::image::atlas::{self, allocator};
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Allocation {
     Partial {
         layer: usize,

--- a/wgpu/src/image/atlas/allocation.rs
+++ b/wgpu/src/image/atlas/allocation.rs
@@ -1,5 +1,5 @@
 use crate::core::Size;
-use crate::image::atlas::{self, allocator};
+use crate::image::atlas::allocator;
 
 #[derive(Debug, Clone)]
 pub enum Allocation {
@@ -20,10 +20,10 @@ impl Allocation {
         }
     }
 
-    pub fn size(&self) -> Size<u32> {
+    pub fn size(&self, atlas_size: u32) -> Size<u32> {
         match self {
             Allocation::Partial { region, .. } => region.size(),
-            Allocation::Full { .. } => Size::new(atlas::SIZE, atlas::SIZE),
+            Allocation::Full { .. } => Size::new(atlas_size, atlas_size),
         }
     }
 

--- a/wgpu/src/image/atlas/allocator.rs
+++ b/wgpu/src/image/atlas/allocator.rs
@@ -39,6 +39,7 @@ impl Allocator {
     }
 }
 
+#[derive(Clone)]
 pub struct Region {
     allocation: guillotiere::Allocation,
 }

--- a/wgpu/src/image/atlas/entry.rs
+++ b/wgpu/src/image/atlas/entry.rs
@@ -12,9 +12,9 @@ pub enum Entry {
 
 impl Entry {
     #[cfg(feature = "image")]
-    pub fn size(&self) -> Size<u32> {
+    pub fn size(&self, atlas_size: u32) -> Size<u32> {
         match self {
-            Entry::Contiguous(allocation) => allocation.size(),
+            Entry::Contiguous(allocation) => allocation.size(atlas_size),
             Entry::Fragmented { size, .. } => *size,
         }
     }

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -4,7 +4,6 @@ use crate::image::staging::StagingBuffer;
 
 use std::sync::Arc;
 use std::time::Instant;
-use std::hash::Hash;
 
 #[derive(Debug)]
 pub struct Cache {
@@ -54,31 +53,6 @@ impl Cache {
     #[cfg(feature = "svg")]
     pub fn measure_svg(&mut self, handle: &core::svg::Handle) -> Size<u32> {
         self.vector.load(handle).viewport_dimensions()
-    }
-
-    // Process any pending uploads - call this during the render pass
-    pub fn process_pending_uploads(
-        &mut self,
-        device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-    ) -> usize {
-        // First check if growth is needed
-        if self.pending_growth > 0 {
-            log::debug!("Growing atlas by {} layers before uploads", self.pending_growth);
-            self.atlas.grow_if_needed(self.pending_growth, device, encoder);
-            self.pending_growth = 0;
-        }
-        
-        // Process pending uploads in parallel
-        let max_parallel = 8; // Process up to 8 uploads in parallel
-        let processed = self.staging.process_uploads_parallel(
-            &mut self.atlas, device, encoder, max_parallel);
-        
-        if processed > 0 {
-            log::debug!("Processed {} uploads in parallel", processed);
-        }
-        
-        processed
     }
 
     #[cfg(feature = "image")]

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -87,25 +87,33 @@ impl Cache {
         encoder: &mut wgpu::CommandEncoder,
         handle: &core::image::Handle,
     ) -> Option<&atlas::Entry> {
-        // Check if pending growth is needed before uploading
+        // First check for the entry - this is safe since it only borrows immutably
+        let entry_exists = self.raster.get_cached_device_entry(handle).is_some();
+        if entry_exists {
+            // Since we know it exists, we can just get it again without borrowing issues
+            return self.raster.get_cached_device_entry(handle);
+        }
+        
+        // Process pending operations before uploading since we need to do an upload
         if self.pending_growth > 0 {
-            log::debug!("Growing atlas by {} layers before raster upload", self.pending_growth);
+            log::debug!("Growing atlas by {} layers", self.pending_growth);
             self.atlas.grow_if_needed(self.pending_growth, device, encoder);
             self.pending_growth = 0;
         }
         
-        // Process any pending uploads first
+        // Process any pending uploads in parallel
         if self.staging.pending_count() > 0 {
-            let processed = self.process_pending_uploads(device, encoder);
+            let max_uploads = 8; // Process up to 8 uploads in parallel
+            let processed = self.staging.process_uploads_parallel(
+                &mut self.atlas, device, encoder, max_uploads);
+            
             if processed > 0 {
-                log::debug!("Processed {} pending uploads before raster upload", processed);
+                log::debug!("Processed {} uploads in parallel", processed);
             }
         }
         
-        // Now do the main upload - this happens last so we can return the entry
-        let entry = self.raster.upload(device, encoder, handle, &mut self.atlas);
-        
-        entry
+        // Now do the upload since we know it doesn't exist
+        self.raster.upload(device, encoder, handle, &mut self.atlas)
     }
 
     #[cfg(feature = "svg")]

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -1,5 +1,6 @@
 use crate::core::{self, Size};
 use crate::image::atlas::{self, Atlas};
+use crate::image::staging::StagingBuffer;
 
 use std::sync::Arc;
 use std::time::Instant;
@@ -11,6 +12,12 @@ pub struct Cache {
     raster: crate::image::raster::Cache,
     #[cfg(feature = "svg")]
     vector: crate::image::vector::Cache,
+    
+    // Add staging buffer for async uploads
+    staging: StagingBuffer,
+    
+    // Track pending atlas growth to apply on next submission
+    pending_growth: usize,
 }
 
 impl Cache {
@@ -25,6 +32,8 @@ impl Cache {
             raster: crate::image::raster::Cache::default(),
             #[cfg(feature = "svg")]
             vector: crate::image::vector::Cache::default(),
+            staging: StagingBuffer::new(),
+            pending_growth: 0,
         }
     }
 
@@ -46,6 +55,35 @@ impl Cache {
         self.vector.load(handle).viewport_dimensions()
     }
 
+    // Process any pending texture uploads
+    pub fn process_uploads(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+    ) {
+        // First, grow the atlas if needed from previous allocations
+        if self.pending_growth > 0 {
+            self.atlas.grow_if_needed(self.pending_growth, device, encoder);
+            self.pending_growth = 0;
+        }
+        
+        // Then process any queued uploads
+        let start = Instant::now();
+        let count = self.staging.process_uploads(&mut self.atlas, device, encoder);
+        
+        if count > 0 {
+            let process_time = start.elapsed();
+            if process_time.as_millis() > 10 {
+                log::debug!("ASYNC UPLOADS: Processed {} texture uploads in {:.2}ms", 
+                         count, process_time.as_secs_f64() * 1000.0);
+            }
+            
+            if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
+                tracker.record_batch_upload_complete(count);
+            }
+        }
+    }
+
     #[cfg(feature = "image")]
     pub fn upload_raster(
         &mut self,
@@ -55,13 +93,180 @@ impl Cache {
     ) -> Option<&atlas::Entry> {
         let upload_start = Instant::now();
         
-        let result = self.raster.upload(device, encoder, handle, &mut self.atlas);
-        
-        if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
-            tracker.record_upload_complete();
+        // If already in atlas, just return it
+        if self.raster.has_device_entry(handle) {
+            return self.raster.get_cached_device_entry(handle);
         }
         
-        result
+        // Load if needed
+        if !self.raster.has_cache_entry(handle) || !self.raster.has_host_memory(handle) {
+            let _ = self.raster.load(handle);
+        }
+        
+        // Try to process the host memory
+        let mut did_queue_upload = false;
+        
+        // Check if we now have host memory after loading
+        if self.raster.has_host_memory(handle) {
+            // Process the host memory to device memory
+            if let Some(dims) = self.raster.get_image_dimensions(handle) {
+                let width = dims.width;
+                let height = dims.height;
+                
+                // Allocate entry in atlas
+                if let Some(entry) = self.atlas.allocate_entry(device, wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                }) {
+                    // Process the upload based on whether entry is contiguous or fragmented
+                    let should_add_entry = match &entry {
+                        atlas::Entry::Contiguous(allocation) => {
+                            // Queue contiguous upload using staging buffer
+                            if let Some(bytes) = self.raster.get_image_bytes(handle) {
+                                let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+                                let padded_width = ((4 * width as usize) + (align - 1)) & !(align - 1);
+                                let padded_size = padded_width * height as usize;
+                                let mut padded_data = vec![0; padded_size];
+                                
+                                // Copy rows with padding
+                                for y in 0..height as usize {
+                                    let src_offset = y * 4 * width as usize;
+                                    let dst_offset = y * padded_width;
+                                    
+                                    padded_data[dst_offset..dst_offset + 4 * width as usize]
+                                        .copy_from_slice(&bytes[src_offset..src_offset + 4 * width as usize]);
+                                }
+                                
+                                let padding = padded_width - 4 * width as usize;
+                                
+                                // Queue the upload
+                                self.staging.queue_upload(
+                                    &padded_data,
+                                    width,
+                                    height,
+                                    padding as u32,
+                                    0,
+                                    allocation.clone(),
+                                );
+                                
+                                // Note the needed atlas growth
+                                let layers_before = self.atlas.layer_count();
+                                let allocation_layer = allocation.layer();
+                                
+                                if allocation_layer >= layers_before {
+                                    self.pending_growth = 
+                                        self.pending_growth.max(allocation_layer + 1 - layers_before);
+                                }
+                                
+                                true
+                            } else {
+                                false
+                            }
+                        },
+                        atlas::Entry::Fragmented { fragments, .. } => {
+                            // Handle each fragment separately
+                            if let Some(bytes) = self.raster.get_image_bytes(handle) {
+                                let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
+                                
+                                for fragment in fragments {
+                                    let fragment_allocation = &fragment.allocation;
+                                    let fragment_width = fragment_allocation.size().width;
+                                    let fragment_height = fragment_allocation.size().height;
+                                    let fragment_x = fragment.position.0;
+                                    let fragment_y = fragment.position.1;
+                                    
+                                    // Create padded buffer for this fragment
+                                    let fragment_padded_width = ((4 * fragment_width as usize) + (align - 1)) & !(align - 1);
+                                    let fragment_size = fragment_padded_width * fragment_height as usize;
+                                    let mut fragment_data = Vec::with_capacity(fragment_size);
+                                    
+                                    // Copy fragment data row by row
+                                    for y in 0..fragment_height as usize {
+                                        let src_y = fragment_y as usize + y;
+                                        
+                                        if src_y < height as usize {
+                                            let src_offset = src_y * 4 * width as usize + fragment_x as usize * 4;
+                                            let src_end = (src_offset + 4 * fragment_width as usize).min(src_y * 4 * width as usize + 4 * width as usize);
+                                            
+                                            if src_offset < src_end {
+                                                let src_row = &bytes[src_offset..src_end];
+                                                fragment_data.extend_from_slice(src_row);
+                                                
+                                                // Pad if fragment is smaller than allocation
+                                                if src_row.len() < 4 * fragment_width as usize {
+                                                    fragment_data.resize(fragment_data.len() + 4 * fragment_width as usize - src_row.len(), 0);
+                                                }
+                                            } else {
+                                                // Full row padding
+                                                fragment_data.resize(fragment_data.len() + 4 * fragment_width as usize, 0);
+                                            }
+                                        } else {
+                                            // Add padding for rows beyond the source image
+                                            fragment_data.resize(fragment_data.len() + 4 * fragment_width as usize, 0);
+                                        }
+                                        
+                                        // Add padding at end of each row
+                                        let padding = (align - (4 * fragment_width as usize) % align) % align;
+                                        fragment_data.resize(fragment_data.len() + padding, 0);
+                                    }
+                                    
+                                    // Queue the fragment upload
+                                    self.staging.queue_upload(
+                                        &fragment_data,
+                                        fragment_width,
+                                        fragment_height,
+                                        ((4 * fragment_width as usize + (align - 1)) & !(align - 1)) as u32 - 4 * fragment_width,
+                                        0,
+                                        fragment_allocation.clone(),
+                                    );
+                                }
+                                
+                                true
+                            } else {
+                                false
+                            }
+                        }
+                    };
+                    
+                    // Register this entry in the cache
+                    if should_add_entry {
+                        self.raster.insert_device_entry(handle, entry);
+                        did_queue_upload = true;
+                        
+                        if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
+                            // Record that we've queued an upload
+                            let handle_hash = format!("{:?}", handle.id());
+                            tracker.record_image_upload(handle_hash, width, height);
+                        }
+                        
+                        let queue_time = upload_start.elapsed();
+                        if queue_time.as_millis() > 5 {
+                            log::debug!("Queued texture upload in {:.2}ms", 
+                                      queue_time.as_secs_f64() * 1000.0);
+                        }
+                    }
+                }
+            }
+        }
+        
+        // If we have a device entry now, return it
+        if self.raster.has_device_entry(handle) {
+            return self.raster.get_cached_device_entry(handle);
+        }
+        
+        // Fallback to synchronous upload if we couldn't queue an upload
+        if !did_queue_upload {
+            // Do synchronous upload
+            let _ = self.raster.upload(device, encoder, handle, &mut self.atlas);
+            
+            if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
+                tracker.record_upload_complete();
+            }
+        }
+        
+        // Final attempt to get the entry
+        self.raster.get_cached_device_entry(handle)
     }
 
     #[cfg(feature = "svg")]
@@ -74,8 +279,10 @@ impl Cache {
         size: [f32; 2],
         scale: f32,
     ) -> Option<&atlas::Entry> {
-        let upload_start = Instant::now();
+        let _upload_start = Instant::now(); // Add underscore to suppress warning
         
+        // TODO: Implement async vector upload similar to raster
+        // For now, use the existing synchronous implementation
         let result = self.vector.upload(
             device,
             encoder,

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -18,6 +18,9 @@ pub struct Cache {
     
     // Track pending atlas growth to apply on next submission
     pending_growth: usize,
+    
+    // Whether to use parallel processing for image uploads
+    use_parallel_processing: bool,
 }
 
 impl Cache {
@@ -34,6 +37,7 @@ impl Cache {
             vector: crate::image::vector::Cache::default(),
             staging: StagingBuffer::new(),
             pending_growth: 0,
+            use_parallel_processing: true,
         }
     }
 
@@ -57,6 +61,16 @@ impl Cache {
 
     #[cfg(feature = "image")]
     pub fn upload_raster(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &core::image::Handle,
+    ) -> Option<&atlas::Entry> {
+        self.raster.upload(device, encoder, handle, &mut self.atlas)
+    }
+
+    #[cfg(feature = "image")]
+    pub fn upload_raster_parallel(
         &mut self,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
@@ -171,9 +185,30 @@ impl Cache {
         self.vector.trim(&mut self.atlas);
     }
 
-    // Add debug information
+    // Debug information
     pub fn log_state(&self) {
         log::debug!("Cache state: Atlas has {} layers, {} pending uploads", 
                   self.atlas.layer_count(), self.staging.pending_count());
+    }
+
+    // Setter for use_parallel_processing
+    pub fn set_parallel_processing(&mut self, enabled: bool) {
+        self.use_parallel_processing = enabled;
+    }
+    
+    // A wrapper for upload raster methods, called by Pipeline::prepare
+    pub fn upload(
+        &mut self,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        handle: &core::image::Handle,
+    ) -> Option<&atlas::Entry> {
+        if self.use_parallel_processing {
+            log::debug!("Using parallel processing for image upload");
+            self.upload_raster_parallel(device, encoder, handle)
+        } else {
+            log::debug!("Using synchronous processing for image upload");
+            self.upload_raster(device, encoder, handle)
+        }
     }
 }

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -4,6 +4,7 @@ use crate::image::staging::StagingBuffer;
 
 use std::sync::Arc;
 use std::time::Instant;
+use std::hash::Hash;
 
 #[derive(Debug)]
 pub struct Cache {
@@ -87,33 +88,74 @@ impl Cache {
         encoder: &mut wgpu::CommandEncoder,
         handle: &core::image::Handle,
     ) -> Option<&atlas::Entry> {
-        // First check for the entry - this is safe since it only borrows immutably
+        // Generate a unique ID for this handle for logging
+        use std::hash::{Hash, Hasher};
+        let mut hasher = std::collections::hash_map::DefaultHasher::new();
+        handle.id().hash(&mut hasher);
+        let handle_id = hasher.finish();
+        
+        // Check if entry exists *without retaining a reference*
         let entry_exists = self.raster.get_cached_device_entry(handle).is_some();
+        
         if entry_exists {
-            // Since we know it exists, we can just get it again without borrowing issues
-            return self.raster.get_cached_device_entry(handle);
-        }
-        
-        // Process pending operations before uploading since we need to do an upload
-        if self.pending_growth > 0 {
-            log::debug!("Growing atlas by {} layers", self.pending_growth);
-            self.atlas.grow_if_needed(self.pending_growth, device, encoder);
-            self.pending_growth = 0;
-        }
-        
-        // Process any pending uploads in parallel
-        if self.staging.pending_count() > 0 {
-            let max_uploads = 8; // Process up to 8 uploads in parallel
-            let processed = self.staging.process_uploads_parallel(
-                &mut self.atlas, device, encoder, max_uploads);
+            log::trace!("Cache hit for image {:#x}", handle_id);
+            // We don't return the reference directly, we'll get it again at the end
+        } else {
+            // Entry doesn't exist, determine if parallel processing is appropriate
+            let should_process_in_parallel = match handle {
+                core::image::Handle::Bytes(_, bytes) if bytes.len() > 50_000 => true,
+                core::image::Handle::Path(_, _) => true, 
+                _ => false,
+            };
             
-            if processed > 0 {
-                log::debug!("Processed {} uploads in parallel", processed);
+            if should_process_in_parallel {
+                // Extract the bytes for processing
+                let data: Vec<u8> = match handle {
+                    core::image::Handle::Bytes(_, bytes) => bytes.to_vec(),
+                    core::image::Handle::Path(_, path) => {
+                        std::fs::read(path).unwrap_or_else(|e| {
+                            log::error!("Failed to read image from path {:?}: {}", path, e);
+                            vec![]
+                        })
+                    },
+                    core::image::Handle::Rgba { pixels, .. } => pixels.to_vec(),
+                };
+                
+                if !data.is_empty() {
+                    log::info!("Submitting image {:#x} for parallel processing ({} bytes)", 
+                             handle_id, data.len());
+                    self.staging.submit_for_processing(data, handle_id);
+                }
+            }
+            
+            // Handle pending growth
+            if self.pending_growth > 0 {
+                self.atlas.grow_if_needed(self.pending_growth, device, encoder);
+                self.pending_growth = 0;
+            }
+            
+            // Process parallel uploads
+            if self.staging.pending_count() > 0 {
+                let processed = self.staging.process_uploads_parallel(
+                    &mut self.atlas, device, encoder, 8);
+                
+                if processed > 0 {
+                    log::debug!("Processed {} uploads in parallel", processed);
+                }
+            }
+            
+            // Check if our image was processed in parallel without retaining a reference
+            let processed_in_parallel = self.raster.get_cached_device_entry(handle).is_some();
+            
+            if !processed_in_parallel {
+                // Fall back to synchronous upload
+                log::debug!("Using synchronous upload for image {:#x}", handle_id);
+                let _ = self.raster.upload(device, encoder, handle, &mut self.atlas);
             }
         }
         
-        // Now do the upload since we know it doesn't exist
-        self.raster.upload(device, encoder, handle, &mut self.atlas)
+        // Now get the entry at the end, after all modifications
+        self.raster.get_cached_device_entry(handle)
     }
 
     #[cfg(feature = "svg")]

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -55,33 +55,28 @@ impl Cache {
         self.vector.load(handle).viewport_dimensions()
     }
 
-    // Process any pending texture uploads
-    pub fn process_uploads(
+    // Process any pending uploads - call this during the render pass
+    pub fn process_pending_uploads(
         &mut self,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
-    ) {
-        // First, grow the atlas if needed from previous allocations
+    ) -> usize {
+        // First check if growth is needed
         if self.pending_growth > 0 {
+            log::debug!("Growing atlas by {} layers before uploads", self.pending_growth);
             self.atlas.grow_if_needed(self.pending_growth, device, encoder);
             self.pending_growth = 0;
         }
         
-        // Then process any queued uploads
-        let start = Instant::now();
-        let count = self.staging.process_uploads(&mut self.atlas, device, encoder);
+        // Now process pending uploads
+        let processed = self.staging.process_uploads(&mut self.atlas, device, encoder);
         
-        if count > 0 {
-            let process_time = start.elapsed();
-            if process_time.as_millis() > 10 {
-                log::debug!("ASYNC UPLOADS: Processed {} texture uploads in {:.2}ms", 
-                         count, process_time.as_secs_f64() * 1000.0);
-            }
-            
-            if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
-                tracker.record_batch_upload_complete(count);
-            }
+        if processed > 0 {
+            log::debug!("Processed {} uploads, {} still pending", 
+                      processed, self.staging.pending_count());
         }
+        
+        processed
     }
 
     #[cfg(feature = "image")]
@@ -91,182 +86,25 @@ impl Cache {
         encoder: &mut wgpu::CommandEncoder,
         handle: &core::image::Handle,
     ) -> Option<&atlas::Entry> {
-        let upload_start = Instant::now();
-        
-        // If already in atlas, just return it
-        if self.raster.has_device_entry(handle) {
-            return self.raster.get_cached_device_entry(handle);
+        // Check if pending growth is needed before uploading
+        if self.pending_growth > 0 {
+            log::debug!("Growing atlas by {} layers before raster upload", self.pending_growth);
+            self.atlas.grow_if_needed(self.pending_growth, device, encoder);
+            self.pending_growth = 0;
         }
         
-        // Load if needed
-        if !self.raster.has_cache_entry(handle) || !self.raster.has_host_memory(handle) {
-            let _ = self.raster.load(handle);
-        }
-        
-        // Try to process the host memory
-        let mut did_queue_upload = false;
-        
-        // Check if we now have host memory after loading
-        if self.raster.has_host_memory(handle) {
-            // Process the host memory to device memory
-            if let Some(dims) = self.raster.get_image_dimensions(handle) {
-                let width = dims.width;
-                let height = dims.height;
-                
-                // Allocate entry in atlas
-                if let Some(entry) = self.atlas.allocate_entry(device, wgpu::Extent3d {
-                    width,
-                    height,
-                    depth_or_array_layers: 1,
-                }) {
-                    // Process the upload based on whether entry is contiguous or fragmented
-                    let should_add_entry = match &entry {
-                        atlas::Entry::Contiguous(allocation) => {
-                            // Queue contiguous upload using staging buffer
-                            if let Some(bytes) = self.raster.get_image_bytes(handle) {
-                                let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
-                                let padded_width = ((4 * width as usize) + (align - 1)) & !(align - 1);
-                                let padded_size = padded_width * height as usize;
-                                let mut padded_data = vec![0; padded_size];
-                                
-                                // Copy rows with padding
-                                for y in 0..height as usize {
-                                    let src_offset = y * 4 * width as usize;
-                                    let dst_offset = y * padded_width;
-                                    
-                                    padded_data[dst_offset..dst_offset + 4 * width as usize]
-                                        .copy_from_slice(&bytes[src_offset..src_offset + 4 * width as usize]);
-                                }
-                                
-                                let padding = padded_width - 4 * width as usize;
-                                
-                                // Queue the upload
-                                self.staging.queue_upload(
-                                    &padded_data,
-                                    width,
-                                    height,
-                                    padding as u32,
-                                    0,
-                                    allocation.clone(),
-                                );
-                                
-                                // Note the needed atlas growth
-                                let layers_before = self.atlas.layer_count();
-                                let allocation_layer = allocation.layer();
-                                
-                                if allocation_layer >= layers_before {
-                                    self.pending_growth = 
-                                        self.pending_growth.max(allocation_layer + 1 - layers_before);
-                                }
-                                
-                                true
-                            } else {
-                                false
-                            }
-                        },
-                        atlas::Entry::Fragmented { fragments, .. } => {
-                            // Handle each fragment separately
-                            if let Some(bytes) = self.raster.get_image_bytes(handle) {
-                                let align = wgpu::COPY_BYTES_PER_ROW_ALIGNMENT as usize;
-                                
-                                for fragment in fragments {
-                                    let fragment_allocation = &fragment.allocation;
-                                    let fragment_width = fragment_allocation.size().width;
-                                    let fragment_height = fragment_allocation.size().height;
-                                    let fragment_x = fragment.position.0;
-                                    let fragment_y = fragment.position.1;
-                                    
-                                    // Create padded buffer for this fragment
-                                    let fragment_padded_width = ((4 * fragment_width as usize) + (align - 1)) & !(align - 1);
-                                    let fragment_size = fragment_padded_width * fragment_height as usize;
-                                    let mut fragment_data = Vec::with_capacity(fragment_size);
-                                    
-                                    // Copy fragment data row by row
-                                    for y in 0..fragment_height as usize {
-                                        let src_y = fragment_y as usize + y;
-                                        
-                                        if src_y < height as usize {
-                                            let src_offset = src_y * 4 * width as usize + fragment_x as usize * 4;
-                                            let src_end = (src_offset + 4 * fragment_width as usize).min(src_y * 4 * width as usize + 4 * width as usize);
-                                            
-                                            if src_offset < src_end {
-                                                let src_row = &bytes[src_offset..src_end];
-                                                fragment_data.extend_from_slice(src_row);
-                                                
-                                                // Pad if fragment is smaller than allocation
-                                                if src_row.len() < 4 * fragment_width as usize {
-                                                    fragment_data.resize(fragment_data.len() + 4 * fragment_width as usize - src_row.len(), 0);
-                                                }
-                                            } else {
-                                                // Full row padding
-                                                fragment_data.resize(fragment_data.len() + 4 * fragment_width as usize, 0);
-                                            }
-                                        } else {
-                                            // Add padding for rows beyond the source image
-                                            fragment_data.resize(fragment_data.len() + 4 * fragment_width as usize, 0);
-                                        }
-                                        
-                                        // Add padding at end of each row
-                                        let padding = (align - (4 * fragment_width as usize) % align) % align;
-                                        fragment_data.resize(fragment_data.len() + padding, 0);
-                                    }
-                                    
-                                    // Queue the fragment upload
-                                    self.staging.queue_upload(
-                                        &fragment_data,
-                                        fragment_width,
-                                        fragment_height,
-                                        ((4 * fragment_width as usize + (align - 1)) & !(align - 1)) as u32 - 4 * fragment_width,
-                                        0,
-                                        fragment_allocation.clone(),
-                                    );
-                                }
-                                
-                                true
-                            } else {
-                                false
-                            }
-                        }
-                    };
-                    
-                    // Register this entry in the cache
-                    if should_add_entry {
-                        self.raster.insert_device_entry(handle, entry);
-                        did_queue_upload = true;
-                        
-                        if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
-                            // Record that we've queued an upload
-                            let handle_hash = format!("{:?}", handle.id());
-                            tracker.record_image_upload(handle_hash, width, height);
-                        }
-                        
-                        let queue_time = upload_start.elapsed();
-                        if queue_time.as_millis() > 5 {
-                            log::debug!("Queued texture upload in {:.2}ms", 
-                                      queue_time.as_secs_f64() * 1000.0);
-                        }
-                    }
-                }
+        // Process any pending uploads first
+        if self.staging.pending_count() > 0 {
+            let processed = self.process_pending_uploads(device, encoder);
+            if processed > 0 {
+                log::debug!("Processed {} pending uploads before raster upload", processed);
             }
         }
         
-        // If we have a device entry now, return it
-        if self.raster.has_device_entry(handle) {
-            return self.raster.get_cached_device_entry(handle);
-        }
+        // Now do the main upload - this happens last so we can return the entry
+        let entry = self.raster.upload(device, encoder, handle, &mut self.atlas);
         
-        // Fallback to synchronous upload if we couldn't queue an upload
-        if !did_queue_upload {
-            // Do synchronous upload
-            let _ = self.raster.upload(device, encoder, handle, &mut self.atlas);
-            
-            if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
-                tracker.record_upload_complete();
-            }
-        }
-        
-        // Final attempt to get the entry
-        self.raster.get_cached_device_entry(handle)
+        entry
     }
 
     #[cfg(feature = "svg")]
@@ -306,5 +144,11 @@ impl Cache {
 
         #[cfg(feature = "svg")]
         self.vector.trim(&mut self.atlas);
+    }
+
+    // Add debug information
+    pub fn log_state(&self) {
+        log::debug!("Cache state: Atlas has {} layers, {} pending uploads", 
+                  self.atlas.layer_count(), self.staging.pending_count());
     }
 }

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -68,12 +68,13 @@ impl Cache {
             self.pending_growth = 0;
         }
         
-        // Now process pending uploads
-        let processed = self.staging.process_uploads(&mut self.atlas, device, encoder);
+        // Process pending uploads in parallel
+        let max_parallel = 8; // Process up to 8 uploads in parallel
+        let processed = self.staging.process_uploads_parallel(
+            &mut self.atlas, device, encoder, max_parallel);
         
         if processed > 0 {
-            log::debug!("Processed {} uploads, {} still pending", 
-                      processed, self.staging.pending_count());
+            log::debug!("Processed {} uploads in parallel", processed);
         }
         
         processed

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -2,6 +2,7 @@ use crate::core::{self, Size};
 use crate::image::atlas::{self, Atlas};
 
 use std::sync::Arc;
+use std::time::Instant;
 
 #[derive(Debug)]
 pub struct Cache {
@@ -52,7 +53,15 @@ impl Cache {
         encoder: &mut wgpu::CommandEncoder,
         handle: &core::image::Handle,
     ) -> Option<&atlas::Entry> {
-        self.raster.upload(device, encoder, handle, &mut self.atlas)
+        let upload_start = Instant::now();
+        
+        let result = self.raster.upload(device, encoder, handle, &mut self.atlas);
+        
+        if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
+            tracker.record_upload_complete();
+        }
+        
+        result
     }
 
     #[cfg(feature = "svg")]
@@ -65,7 +74,9 @@ impl Cache {
         size: [f32; 2],
         scale: f32,
     ) -> Option<&atlas::Entry> {
-        self.vector.upload(
+        let upload_start = Instant::now();
+        
+        let result = self.vector.upload(
             device,
             encoder,
             handle,
@@ -73,7 +84,13 @@ impl Cache {
             size,
             scale,
             &mut self.atlas,
-        )
+        );
+        
+        if let Ok(mut tracker) = crate::image::IMAGE_DISPLAY_TRACKER.lock() {
+            tracker.record_upload_complete();
+        }
+        
+        result
     }
 
     pub fn trim(&mut self) {

--- a/wgpu/src/image/cache.rs
+++ b/wgpu/src/image/cache.rs
@@ -21,6 +21,9 @@ pub struct Cache {
     
     // Whether to use parallel processing for image uploads
     use_parallel_processing: bool,
+
+    // Atlas size
+    atlas_size: u32,
 }
 
 impl Cache {
@@ -28,9 +31,10 @@ impl Cache {
         device: &wgpu::Device,
         backend: wgpu::Backend,
         layout: Arc<wgpu::BindGroupLayout>,
+        atlas_size: u32,
     ) -> Self {
         Self {
-            atlas: Atlas::new(device, backend, layout),
+            atlas: Atlas::new(device, backend, layout, atlas_size),
             #[cfg(feature = "image")]
             raster: crate::image::raster::Cache::default(),
             #[cfg(feature = "svg")]
@@ -38,7 +42,12 @@ impl Cache {
             staging: StagingBuffer::new(),
             pending_growth: 0,
             use_parallel_processing: true,
+            atlas_size: atlas_size,
         }
+    }
+
+    pub fn atlas_size(&self) -> u32 {
+        self.atlas_size
     }
 
     pub fn bind_group(&self) -> &wgpu::BindGroup {
@@ -51,7 +60,7 @@ impl Cache {
 
     #[cfg(feature = "image")]
     pub fn measure_image(&mut self, handle: &core::image::Handle) -> Size<u32> {
-        self.raster.load(handle).dimensions()
+        self.raster.load(handle).dimensions(self.atlas_size)
     }
 
     #[cfg(feature = "svg")]

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -228,7 +228,8 @@ impl Pipeline {
                 #[cfg(feature = "image")]
                 Image::Raster(image, bounds) => {
                     if let Some(atlas_entry) =
-                        cache.upload_raster(device, encoder, &image.handle)
+                        //cache.upload_raster(device, encoder, &image.handle)
+                        cache.upload(device, encoder, &image.handle)
                     {
                         add_instances(
                             [bounds.x, bounds.y],

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod cache;
 pub(crate) use cache::Cache;
 
 pub mod atlas;
+
 mod staging;
 
 #[cfg(feature = "image")]

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -1,7 +1,7 @@
 pub(crate) mod cache;
 pub(crate) use cache::Cache;
 
-mod atlas;
+pub mod atlas;
 mod staging;
 
 #[cfg(feature = "image")]
@@ -206,8 +206,13 @@ impl Pipeline {
         }
     }
 
-    pub fn create_cache(&self, device: &wgpu::Device) -> Cache {
-        Cache::new(device, self.backend, self.texture_layout.clone())
+    pub fn create_cache(&self, device: &wgpu::Device, atlas_size: u32) -> Cache {
+        Cache::new(
+            device,
+            self.backend,
+            self.texture_layout.clone(),
+            atlas_size,
+        )
     }
 
     pub fn prepare(
@@ -222,6 +227,7 @@ impl Pipeline {
     ) {
         let nearest_instances: &mut Vec<Instance> = &mut Vec::new();
         let linear_instances: &mut Vec<Instance> = &mut Vec::new();
+        let atlas_size = cache.atlas_size();
 
         for image in images {
             match &image {
@@ -238,6 +244,7 @@ impl Pipeline {
                             image.opacity,
                             image.snap,
                             atlas_entry,
+                            atlas_size,
                             match image.filter_method {
                                 crate::core::image::FilterMethod::Nearest => {
                                     nearest_instances
@@ -271,6 +278,7 @@ impl Pipeline {
                             svg.opacity,
                             true,
                             atlas_entry,
+                            atlas_size,
                             nearest_instances,
                         );
                     }
@@ -529,6 +537,7 @@ fn add_instances(
     opacity: f32,
     snap: bool,
     entry: &atlas::Entry,
+    atlas_size: u32,
     instances: &mut Vec<Instance>,
 ) {
     let center = [
@@ -546,6 +555,7 @@ fn add_instances(
                 opacity,
                 snap,
                 allocation,
+                atlas_size,
                 instances,
             );
         }
@@ -561,7 +571,7 @@ fn add_instances(
                 let Size {
                     width: fragment_width,
                     height: fragment_height,
-                } = allocation.size();
+                } = allocation.size(atlas_size);
 
                 let position = [
                     x + fragment_x as f32 * scaling_x,
@@ -575,7 +585,7 @@ fn add_instances(
 
                 add_instance(
                     position, center, size, rotation, opacity, snap,
-                    allocation, instances,
+                    allocation, atlas_size, instances,
                 );
             }
         }
@@ -591,10 +601,11 @@ fn add_instance(
     opacity: f32,
     snap: bool,
     allocation: &atlas::Allocation,
+    atlas_size: u32,
     instances: &mut Vec<Instance>,
 ) {
     let (x, y) = allocation.position();
-    let Size { width, height } = allocation.size();
+    let Size { width, height } = allocation.size(atlas_size);
     let layer = allocation.layer();
 
     let instance = Instance {
@@ -604,12 +615,12 @@ fn add_instance(
         _rotation: rotation,
         _opacity: opacity,
         _position_in_atlas: [
-            (x as f32 + 0.5) / atlas::SIZE as f32,
-            (y as f32 + 0.5) / atlas::SIZE as f32,
+            (x as f32 + 0.5) / atlas_size as f32,
+            (y as f32 + 0.5) / atlas_size as f32,
         ],
         _size_in_atlas: [
-            (width as f32 - 1.0) / atlas::SIZE as f32,
-            (height as f32 - 1.0) / atlas::SIZE as f32,
+            (width as f32 - 1.0) / atlas_size as f32,
+            (height as f32 - 1.0) / atlas_size as f32,
         ],
         _layer: layer as u32,
         _snap: snap as u32,

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -636,10 +636,14 @@ pub struct ImageDisplayTracker {
     // Calculated FPS value
     fps: f64,
     
-    // Add new timing fields
+    // Add new timing fields and stats
     upload_durations: VecDeque<Duration>,
     render_durations: VecDeque<Duration>,
     current_upload_start: Option<Instant>,
+    current_render_start: Option<Instant>,
+    max_render_duration: Duration,
+    min_render_duration: Duration,
+    pub total_frames_rendered: usize,
 }
 
 impl ImageDisplayTracker {
@@ -652,6 +656,10 @@ impl ImageDisplayTracker {
             upload_durations: VecDeque::with_capacity(100),
             render_durations: VecDeque::with_capacity(100),
             current_upload_start: None,
+            current_render_start: None,
+            max_render_duration: Duration::from_millis(0),
+            min_render_duration: Duration::from_secs(1000),
+            total_frames_rendered: 0,
         }
     }
     
@@ -734,12 +742,63 @@ impl ImageDisplayTracker {
         }
     }
 
-    // Fix the render_durations trimming
+    // Update record_render_duration to log outliers
     pub fn record_render_duration(&mut self, duration: Duration) {
         self.render_durations.push_back(duration);
+        
+        self.total_frames_rendered += 1;
+        
+        // Track min/max for outlier detection
+        if duration > self.max_render_duration {
+            self.max_render_duration = duration;
+            println!("SLOW FRAME DETECTED: {:.2}ms", duration.as_secs_f64() * 1000.0);
+        }
+        
+        if duration < self.min_render_duration {
+            self.min_render_duration = duration;
+        }
+        
+        // Log every 50th frame for monitoring
+        if self.total_frames_rendered % 50 == 0 {
+            let (avg_upload, avg_render) = self.get_timing_stats();
+            println!("RENDER STATS: Frames: {}, FPS: {:.2}, Avg Render: {:.2}ms, Min: {:.2}ms, Max: {:.2}ms", 
+                    self.total_frames_rendered, 
+                    self.fps,
+                    avg_render * 1000.0,
+                    self.min_render_duration.as_secs_f64() * 1000.0,
+                    self.max_render_duration.as_secs_f64() * 1000.0);
+        }
+        
         while self.render_durations.len() > 100 {
             let _ = self.render_durations.pop_front();
         }
+    }
+
+    // Start timing a render operation
+    pub fn start_render_timing(&mut self) {
+        self.current_render_start = Some(Instant::now());
+    }
+    
+    // Complete timing a render operation
+    pub fn complete_render_timing(&mut self) {
+        if let Some(start) = self.current_render_start.take() {
+            let duration = start.elapsed();
+            self.record_render_duration(duration);
+        }
+    }
+    
+    // Enhanced method to get timing stats with more details
+    pub fn get_detailed_timing_stats(&self) -> (f64, f64, f64, f64, f64) {
+        let (avg_upload, avg_render) = self.get_timing_stats();
+        
+        let max_render = self.max_render_duration.as_secs_f64();
+        let min_render = if self.total_frames_rendered > 0 {
+            self.min_render_duration.as_secs_f64()
+        } else {
+            0.0
+        };
+        
+        (self.fps, avg_upload, avg_render, min_render, max_render)
     }
 
     // Add method to get average timings
@@ -770,6 +829,13 @@ pub fn record_image_upload(handle_hash: String, width: u32, height: u32) {
     }
 }
 
+// Add this new function to record rendering time measurements
+pub fn record_image_render_duration(duration: Duration) {
+    if let Ok(mut tracker) = IMAGE_DISPLAY_TRACKER.lock() {
+        tracker.record_render_duration(duration);
+    }
+}
+
 /// Get the current image rendering FPS 
 /// This is a global function accessible to applications
 pub fn get_image_display_fps() -> f64 {
@@ -793,4 +859,23 @@ pub fn sync_image_tracker_timestamps(timestamps: VecDeque<Instant>) {
     if let Ok(mut tracker) = IMAGE_DISPLAY_TRACKER.lock() {
         tracker.sync_from_external(timestamps);
     }
+}
+
+// Add new function to get detailed performance metrics with logging
+pub fn get_image_rendering_stats_with_logging() -> (f64, f64, f64) {
+    if let Ok(tracker) = IMAGE_DISPLAY_TRACKER.lock() {
+        let fps = tracker.get_fps();
+        let (avg_upload, avg_render) = tracker.get_timing_stats();
+        
+        println!("IMAGE PERFORMANCE: FPS: {:.2}, Upload: {:.2}ms, Render: {:.2}ms", 
+                 fps, avg_upload * 1000.0, avg_render * 1000.0);
+        
+        // Log additional stats about recent frames
+        if let Some(last_render) = tracker.render_durations.back() {
+            println!("LAST FRAME: Render time: {:.2}ms", last_render.as_secs_f64() * 1000.0);
+        }
+        
+        return (fps, avg_upload, avg_render);
+    }
+    (0.0, 0.0, 0.0)
 }

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -2,6 +2,7 @@ pub(crate) mod cache;
 pub(crate) use cache::Cache;
 
 mod atlas;
+mod staging;
 
 #[cfg(feature = "image")]
 mod raster;
@@ -818,6 +819,33 @@ impl ImageDisplayTracker {
         };
         
         (avg_upload, avg_render)
+    }
+
+    // Add method to start upload timing
+    pub fn start_upload_timing(&mut self) {
+        self.current_upload_start = Some(Instant::now());
+    }
+    
+    // Add method to handle batch uploads
+    pub fn record_batch_upload_complete(&mut self, count: usize) {
+        if let Some(start) = self.current_upload_start.take() {
+            let duration = start.elapsed();
+            
+            // Record the average duration per texture
+            if count > 0 {
+                let avg_duration = duration.div_f32(count as f32);
+                self.upload_durations.push_back(avg_duration);
+                
+                while self.upload_durations.len() > 100 {
+                    let _ = self.upload_durations.pop_front();
+                }
+                
+                if avg_duration.as_millis() > 20 {
+                    log::warn!("SLOW BATCH UPLOAD: {:.2}ms avg for {} textures", 
+                             avg_duration.as_secs_f64() * 1000.0, count);
+                }
+            }
+        }
     }
 }
 

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -907,3 +907,33 @@ pub fn get_image_rendering_stats_with_logging() -> (f64, f64, f64) {
     }
     (0.0, 0.0, 0.0)
 }
+
+// Fix the debug_image_upload_status function to use existing fields
+
+pub fn debug_image_upload_status() {
+    if let Ok(tracker) = IMAGE_DISPLAY_TRACKER.lock() {
+        // Use the fields that actually exist in ImageDisplayTracker
+        let uploads_pending = tracker.upload_timestamps.len();
+        let total_frames = tracker.total_frames_rendered;
+        
+        println!("IMAGE UPLOAD STATUS:");
+        println!("  Recent uploads: {}", uploads_pending);
+        println!("  Total frames rendered: {}", total_frames);
+        println!("  Current FPS: {:.2}", tracker.fps);
+        
+        // Get timing statistics
+        let (avg_upload, avg_render) = tracker.get_timing_stats();
+        println!("  Average upload time: {:.2}ms", avg_upload * 1000.0);
+        println!("  Average render time: {:.2}ms", avg_render * 1000.0);
+        println!("  Min render time: {:.2}ms", tracker.min_render_duration.as_secs_f64() * 1000.0);
+        println!("  Max render time: {:.2}ms", tracker.max_render_duration.as_secs_f64() * 1000.0);
+        
+        // Show recent uploads
+        if !tracker.uploaded_images.is_empty() {
+            println!("RECENTLY UPLOADED IMAGES:");
+            for image_identifier in &tracker.uploaded_images {
+                println!("  {}", image_identifier);
+            }
+        }
+    }
+}

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -313,6 +313,8 @@ impl Pipeline {
         bounds: Rectangle<u32>,
         render_pass: &mut wgpu::RenderPass<'a>,
     ) {
+        let render_start = Instant::now();
+        
         if let Some(layer) = self.layers.get(layer) {
             render_pass.set_pipeline(&self.pipeline);
 
@@ -326,6 +328,11 @@ impl Pipeline {
             render_pass.set_bind_group(1, cache.bind_group(), &[]);
 
             layer.render(render_pass);
+        }
+        
+        // Record render duration
+        if let Ok(mut tracker) = IMAGE_DISPLAY_TRACKER.lock() {
+            tracker.record_render_duration(render_start.elapsed());
         }
     }
 
@@ -628,6 +635,11 @@ pub struct ImageDisplayTracker {
     
     // Calculated FPS value
     fps: f64,
+    
+    // Add new timing fields
+    upload_durations: VecDeque<Duration>,
+    render_durations: VecDeque<Duration>,
+    current_upload_start: Option<Instant>,
 }
 
 impl ImageDisplayTracker {
@@ -637,6 +649,9 @@ impl ImageDisplayTracker {
             upload_timestamps: VecDeque::with_capacity(120),
             uploaded_images: HashSet::new(),
             fps: 0.0,
+            upload_durations: VecDeque::with_capacity(100),
+            render_durations: VecDeque::with_capacity(100),
+            current_upload_start: None,
         }
     }
     
@@ -653,6 +668,9 @@ impl ImageDisplayTracker {
         
         // Calculate FPS
         self.calculate_fps();
+        
+        // Start timing the upload process
+        self.current_upload_start = Some(Instant::now());
     }
     
     /// Calculate FPS from upload timestamps
@@ -701,6 +719,46 @@ impl ImageDisplayTracker {
             self.upload_timestamps = timestamps;
             self.calculate_fps();
         }
+    }
+
+    // Fix the upload_durations trimming
+    pub fn record_upload_complete(&mut self) {
+        if let Some(start) = self.current_upload_start.take() {
+            let duration = start.elapsed();
+            self.upload_durations.push_back(duration);
+            
+            // Trim old entries - use let _ = to explicitly discard the result
+            while self.upload_durations.len() > 100 {
+                let _ = self.upload_durations.pop_front();
+            }
+        }
+    }
+
+    // Fix the render_durations trimming
+    pub fn record_render_duration(&mut self, duration: Duration) {
+        self.render_durations.push_back(duration);
+        while self.render_durations.len() > 100 {
+            let _ = self.render_durations.pop_front();
+        }
+    }
+
+    // Add method to get average timings
+    pub fn get_timing_stats(&self) -> (f64, f64) {
+        let avg_upload = if self.upload_durations.is_empty() {
+            0.0
+        } else {
+            self.upload_durations.iter().sum::<Duration>().as_secs_f64() 
+                / self.upload_durations.len() as f64
+        };
+        
+        let avg_render = if self.render_durations.is_empty() {
+            0.0
+        } else {
+            self.render_durations.iter().sum::<Duration>().as_secs_f64()
+                / self.render_durations.len() as f64
+        };
+        
+        (avg_upload, avg_render)
     }
 }
 

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -761,7 +761,7 @@ impl ImageDisplayTracker {
         
         // Log every 50th frame for monitoring
         if self.total_frames_rendered % 50 == 0 {
-            let (avg_upload, avg_render) = self.get_timing_stats();
+            let (_avg_upload, avg_render) = self.get_timing_stats();
             println!("RENDER STATS: Frames: {}, FPS: {:.2}, Avg Render: {:.2}ms, Min: {:.2}ms, Max: {:.2}ms", 
                     self.total_frames_rendered, 
                     self.fps,

--- a/wgpu/src/image/mod.rs
+++ b/wgpu/src/image/mod.rs
@@ -650,7 +650,7 @@ pub struct ImageDisplayTracker {
 impl ImageDisplayTracker {
     fn new() -> Self {
         Self {
-            window_duration: Duration::from_secs(5),
+            window_duration: Duration::from_secs(2),
             upload_timestamps: VecDeque::with_capacity(120),
             uploaded_images: HashSet::new(),
             fps: 0.0,

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -3,6 +3,8 @@ use crate::core::Size;
 use crate::graphics;
 use crate::graphics::image::image_rs;
 use crate::image::atlas::{self, Atlas};
+use image_rs::{ImageBuffer, Rgba};
+use crate::core::image::Bytes;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
@@ -10,7 +12,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 #[derive(Debug)]
 pub enum Memory {
     /// Image data on host
-    Host(image_rs::ImageBuffer<image_rs::Rgba<u8>, image::Bytes>),
+    Host(image_rs::ImageBuffer<Rgba<u8>, Bytes>),
     /// Storage entry
     Device(atlas::Entry),
     /// Image not found
@@ -38,7 +40,7 @@ impl Memory {
 /// Caches image raster data
 #[derive(Debug, Default)]
 pub struct Cache {
-    map: FxHashMap<image::Id, Memory>,
+    entries: FxHashMap<image::Id, Memory>,
     hits: FxHashSet<image::Id>,
     should_trim: bool,
 }
@@ -100,7 +102,7 @@ impl Cache {
 
         let hits = &self.hits;
 
-        self.map.retain(|k, memory| {
+        self.entries.retain(|k, memory| {
             let retain = hits.contains(k);
 
             if !retain {
@@ -119,29 +121,29 @@ impl Cache {
     fn get(&mut self, handle: &image::Handle) -> Option<&mut Memory> {
         let _ = self.hits.insert(handle.id());
 
-        self.map.get_mut(&handle.id())
+        self.entries.get_mut(&handle.id())
     }
 
     fn insert(&mut self, handle: &image::Handle, memory: Memory) {
-        let _ = self.map.insert(handle.id(), memory);
+        let _ = self.entries.insert(handle.id(), memory);
     }
 
     fn contains(&self, handle: &image::Handle) -> bool {
-        self.map.contains_key(&handle.id())
+        self.entries.contains_key(&handle.id())
     }
 
     pub fn print_stats(&self) {
         println!(
             "Image cache stats: {} entries, {} hits", 
-            self.map.len(),
+            self.entries.len(),
             self.hits.len()
         );
         
         // Count by memory type
-        let host_count = self.map.values()
+        let host_count = self.entries.values()
             .filter(|mem| matches!(mem, Memory::Host(_)))
             .count();
-        let device_count = self.map.values()
+        let device_count = self.entries.values()
             .filter(|mem| matches!(mem, Memory::Device(_)))
             .count();
             
@@ -149,5 +151,63 @@ impl Cache {
             "Memory locations: {} on host, {} on device",
             host_count, device_count
         );
+    }
+
+    // Add methods to access entries by state
+    
+    // Get a device entry if it exists
+    pub fn get_cached_device_entry(&self, handle: &image::Handle) -> Option<&atlas::Entry> {
+        if let Some(Memory::Device(entry)) = self.entries.get(&handle.id()) {
+            Some(entry)
+        } else {
+            None
+        }
+    }
+    
+    // Get host memory if it exists
+    pub fn get_cached_host_memory(&self, handle: &image::Handle) -> Option<&image_rs::ImageBuffer<Rgba<u8>, Bytes>> {
+        if let Some(Memory::Host(data)) = self.entries.get(&handle.id()) {
+            Some(data)
+        } else {
+            None
+        }
+    }
+    
+    // Insert a device entry directly
+    pub fn insert_device_entry(&mut self, handle: &image::Handle, entry: atlas::Entry) {
+        let _ = self.entries.insert(handle.id(), Memory::Device(entry));
+    }
+
+    // Check if entry exists in cache (any kind)
+    pub fn has_cache_entry(&self, handle: &image::Handle) -> bool {
+        self.entries.contains_key(&handle.id())
+    }
+    
+    // Check if entry is already on device
+    pub fn has_device_entry(&self, handle: &image::Handle) -> bool {
+        matches!(self.entries.get(&handle.id()), Some(Memory::Device(_)))
+    }
+    
+    // Check if we have host memory
+    pub fn has_host_memory(&self, handle: &image::Handle) -> bool {
+        matches!(self.entries.get(&handle.id()), Some(Memory::Host(_)))
+    }
+    
+    // Get dimensions of an image if available
+    pub fn get_image_dimensions(&self, handle: &image::Handle) -> Option<Size<u32>> {
+        if let Some(Memory::Host(data)) = self.entries.get(&handle.id()) {
+            Some(Size::new(data.width(), data.height()))
+        } else {
+            None
+        }
+    }
+    
+    // Get image bytes if available
+    pub fn get_image_bytes(&self, handle: &image::Handle) -> Option<&[u8]> {
+        if let Some(Memory::Host(data)) = self.entries.get(&handle.id()) {
+            Some(data.as_raw())
+        } else {
+            None
+        }
     }
 }

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -129,4 +129,25 @@ impl Cache {
     fn contains(&self, handle: &image::Handle) -> bool {
         self.map.contains_key(&handle.id())
     }
+
+    pub fn print_stats(&self) {
+        println!(
+            "Image cache stats: {} entries, {} hits", 
+            self.map.len(),
+            self.hits.len()
+        );
+        
+        // Count by memory type
+        let host_count = self.map.values()
+            .filter(|mem| matches!(mem, Memory::Host(_)))
+            .count();
+        let device_count = self.map.values()
+            .filter(|mem| matches!(mem, Memory::Device(_)))
+            .count();
+            
+        println!(
+            "Memory locations: {} on host, {} on device",
+            host_count, device_count
+        );
+    }
 }

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -3,7 +3,7 @@ use crate::core::Size;
 use crate::graphics;
 use crate::graphics::image::image_rs;
 use crate::image::atlas::{self, Atlas};
-use image_rs::{ImageBuffer, Rgba};
+use image_rs::Rgba;
 use crate::core::image::Bytes;
 
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -132,6 +132,7 @@ impl Cache {
         self.entries.contains_key(&handle.id())
     }
 
+    #[allow(dead_code)]
     pub fn print_stats(&self) {
         println!(
             "Image cache stats: {} entries, {} hits", 
@@ -153,59 +154,10 @@ impl Cache {
         );
     }
 
-    // Add methods to access entries by state
-    
     // Get a device entry if it exists
     pub fn get_cached_device_entry(&self, handle: &image::Handle) -> Option<&atlas::Entry> {
         if let Some(Memory::Device(entry)) = self.entries.get(&handle.id()) {
             Some(entry)
-        } else {
-            None
-        }
-    }
-    
-    // Get host memory if it exists
-    pub fn get_cached_host_memory(&self, handle: &image::Handle) -> Option<&image_rs::ImageBuffer<Rgba<u8>, Bytes>> {
-        if let Some(Memory::Host(data)) = self.entries.get(&handle.id()) {
-            Some(data)
-        } else {
-            None
-        }
-    }
-    
-    // Insert a device entry directly
-    pub fn insert_device_entry(&mut self, handle: &image::Handle, entry: atlas::Entry) {
-        let _ = self.entries.insert(handle.id(), Memory::Device(entry));
-    }
-
-    // Check if entry exists in cache (any kind)
-    pub fn has_cache_entry(&self, handle: &image::Handle) -> bool {
-        self.entries.contains_key(&handle.id())
-    }
-    
-    // Check if entry is already on device
-    pub fn has_device_entry(&self, handle: &image::Handle) -> bool {
-        matches!(self.entries.get(&handle.id()), Some(Memory::Device(_)))
-    }
-    
-    // Check if we have host memory
-    pub fn has_host_memory(&self, handle: &image::Handle) -> bool {
-        matches!(self.entries.get(&handle.id()), Some(Memory::Host(_)))
-    }
-    
-    // Get dimensions of an image if available
-    pub fn get_image_dimensions(&self, handle: &image::Handle) -> Option<Size<u32>> {
-        if let Some(Memory::Host(data)) = self.entries.get(&handle.id()) {
-            Some(Size::new(data.width(), data.height()))
-        } else {
-            None
-        }
-    }
-    
-    // Get image bytes if available
-    pub fn get_image_bytes(&self, handle: &image::Handle) -> Option<&[u8]> {
-        if let Some(Memory::Host(data)) = self.entries.get(&handle.id()) {
-            Some(data.as_raw())
         } else {
             None
         }

--- a/wgpu/src/image/raster.rs
+++ b/wgpu/src/image/raster.rs
@@ -23,14 +23,14 @@ pub enum Memory {
 
 impl Memory {
     /// Width and height of image
-    pub fn dimensions(&self) -> Size<u32> {
+    pub fn dimensions(&self, atlas_size: u32) -> Size<u32> {
         match self {
             Memory::Host(image) => {
                 let (width, height) = image.dimensions();
 
                 Size::new(width, height)
             }
-            Memory::Device(entry) => entry.size(),
+            Memory::Device(entry) => entry.size(atlas_size),
             Memory::NotFound => Size::new(1, 1),
             Memory::Invalid => Size::new(1, 1),
         }

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -120,4 +120,77 @@ impl StagingBuffer {
     pub fn pending_count(&self) -> usize {
         self.pending_uploads.len()
     }
+
+    pub fn process_uploads_parallel(
+        &mut self,
+        atlas: &mut atlas::Atlas,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+        max_parallel: usize,
+    ) -> usize {
+        let start = Instant::now();
+        let mut processed = 0;
+        
+        // Process uploads in parallel batches
+        let batch_size = std::cmp::min(self.pending_uploads.len(), max_parallel);
+        
+        for _ in 0..batch_size {
+            if let Some(upload) = self.pending_uploads.pop_front() {
+                // Check if allocation is valid
+                if upload.allocation.layer() >= atlas.layer_count() {
+                    log::warn!("Skipping upload to invalid layer {}", upload.allocation.layer());
+                    continue;
+                }
+                
+                // Prepare buffer for upload
+                use wgpu::util::DeviceExt;
+                
+                let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                    label: Some("parallel image upload buffer"),
+                    contents: &upload.data,
+                    usage: wgpu::BufferUsages::COPY_SRC,
+                });
+                
+                // Get upload parameters
+                let (x, y) = upload.allocation.position();
+                let size = upload.allocation.size();
+                
+                // Execute copy operation immediately
+                encoder.copy_buffer_to_texture(
+                    wgpu::ImageCopyBuffer {
+                        buffer: &buffer,
+                        layout: wgpu::ImageDataLayout {
+                            offset: upload.offset as u64,
+                            bytes_per_row: Some(4 * upload.width + upload.padding),
+                            rows_per_image: Some(upload.height),
+                        },
+                    },
+                    wgpu::ImageCopyTexture {
+                        texture: atlas.texture(),
+                        mip_level: 0,
+                        origin: wgpu::Origin3d {
+                            x,
+                            y,
+                            z: upload.allocation.layer() as u32,
+                        },
+                        aspect: wgpu::TextureAspect::default(),
+                    },
+                    wgpu::Extent3d {
+                        width: size.width,
+                        height: size.height,
+                        depth_or_array_layers: 1,
+                    },
+                );
+                
+                processed += 1;
+            }
+        }
+        
+        if processed > 0 {
+            log::debug!("Processed {} uploads in parallel in {:?}", 
+                        processed, start.elapsed());
+        }
+        
+        processed
+    }
 }

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -20,6 +20,8 @@ struct PendingUpload {
 pub struct StagingBuffer {
     pending_uploads: VecDeque<PendingUpload>,
     max_batch_size: usize,
+    total_queued: usize,   // Add stats tracking fields
+    total_processed: usize,
 }
 
 impl StagingBuffer {
@@ -27,6 +29,8 @@ impl StagingBuffer {
         Self {
             pending_uploads: VecDeque::with_capacity(10),
             max_batch_size: 4, // Process up to 4 uploads per frame
+            total_queued: 0,
+            total_processed: 0,
         }
     }
 
@@ -40,6 +44,10 @@ impl StagingBuffer {
         offset: usize,
         allocation: atlas::Allocation,
     ) {
+        // Add detailed logging
+        log::debug!("Queueing texture upload: {}x{} pixels, {}/{} pending", 
+                  width, height, self.pending_uploads.len(), self.pending_count());
+        
         self.pending_uploads.push_back(PendingUpload {
             data: data.to_vec(), // Clone the data (could use a shared buffer in the future)
             width,
@@ -49,6 +57,8 @@ impl StagingBuffer {
             allocation,
             queued_at: Instant::now(),
         });
+        
+        self.total_queued += 1;
     }
 
     /// Process queued uploads up to the batch size limit
@@ -59,18 +69,24 @@ impl StagingBuffer {
         encoder: &mut wgpu::CommandEncoder,
     ) -> usize {
         let start = Instant::now();
-        let count = self.pending_uploads.len().min(self.max_batch_size);
-        
-        if count == 0 {
-            return 0;
-        }
-
         let mut processed = 0;
+        
+        // Determine the number of uploads to process in this batch
+        let pending_count = self.pending_uploads.len();
+        let count = std::cmp::min(pending_count, self.max_batch_size);
         
         // Process the oldest uploads first
         for _ in 0..count {
             if let Some(upload) = self.pending_uploads.pop_front() {
-                let queue_time = upload.queued_at.elapsed();
+                // Check if the allocation is valid before processing
+                let allocation_layer = upload.allocation.layer();
+                let layer_count = atlas.layer_count();
+                
+                if allocation_layer >= layer_count {
+                    log::error!("SKIPPING INVALID UPLOAD: Layer {} exceeds atlas size {}", 
+                               allocation_layer, layer_count);
+                    continue;
+                }
                 
                 // Upload to the atlas texture
                 atlas.upload_allocation(
@@ -85,19 +101,16 @@ impl StagingBuffer {
                 );
                 
                 processed += 1;
-                
-                // Log if uploads were queued for a long time
-                if queue_time.as_millis() > 100 {
-                    log::warn!("Texture upload queued for {}ms before processing", 
-                              queue_time.as_millis());
-                }
             }
         }
         
         let processing_time = start.elapsed();
-        if processed > 0 && processing_time.as_millis() > 5 {
-            log::debug!("Processed {} texture uploads in {:.2}ms", 
-                      processed, processing_time.as_secs_f64() * 1000.0);
+        if processed > 0 {
+            // Always log for debugging
+            log::info!("Processed {}/{} texture uploads in {:.2}ms (total: {}/{})", 
+                     processed, self.pending_uploads.len() + processed,
+                     processing_time.as_secs_f64() * 1000.0,
+                     self.total_processed, self.total_queued);
         }
         
         processed

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -7,9 +7,9 @@ use std::thread;
 use std::sync::{Arc, Mutex};
 use std::sync::mpsc::{channel, Sender, Receiver};
 use crate::image::atlas::Atlas;
-use crate::core::Size;
 
 // Background worker pool for parallel image processing
+#[allow(dead_code)]
 #[derive(Debug)]
 struct ImageWorkerPool {
     sender: Sender<ImageJob>,
@@ -23,6 +23,7 @@ struct ImageJob {
     processed_queue: Arc<Mutex<VecDeque<ProcessedImage>>>,
 }
 
+#[allow(dead_code)]
 #[derive(Debug)]
 struct ProcessedImage {
     data: Vec<u8>,
@@ -40,7 +41,7 @@ impl ImageWorkerPool {
         
         let workers = (0..num_workers).map(|i| {
             let receiver = receiver.clone();
-            let processed_queue = processed_queue.clone();
+            let _processed_queue = processed_queue.clone();
             
             thread::spawn(move || {
                 log::debug!("Image worker {} started", i);
@@ -123,6 +124,7 @@ impl ImageWorkerPool {
 }
 
 /// A single queued texture upload
+#[allow(dead_code)]
 #[derive(Debug)]
 struct PendingUpload {
     data: Vec<u8>,
@@ -138,7 +140,6 @@ struct PendingUpload {
 #[derive(Debug)]
 pub struct StagingBuffer {
     pending_uploads: VecDeque<PendingUpload>,
-    max_batch_size: usize,
     total_queued: usize,   // Add stats tracking fields
     total_processed: usize,
     worker_pool: ImageWorkerPool,
@@ -155,7 +156,6 @@ impl StagingBuffer {
 
         Self {
             pending_uploads: VecDeque::with_capacity(10),
-            max_batch_size: 4, // Process up to 4 uploads per frame
             total_queued: 0,
             total_processed: 0,
             worker_pool: ImageWorkerPool::new(num_workers),
@@ -215,88 +215,7 @@ impl StagingBuffer {
         count
     }
 
-    /// Queue a texture upload to be processed during the next frame submission
-    pub fn queue_upload(
-        &mut self,
-        data: &[u8],
-        width: u32,
-        height: u32,
-        padding: u32,
-        offset: usize,
-        allocation: atlas::Allocation,
-    ) {
-        // Add detailed logging
-        log::debug!("Queueing texture upload: {}x{} pixels, {}/{} pending", 
-                  width, height, self.pending_uploads.len(), self.pending_count());
-        
-        self.pending_uploads.push_back(PendingUpload {
-            data: data.to_vec(), // Clone the data (could use a shared buffer in the future)
-            width,
-            height,
-            padding,
-            offset,
-            allocation,
-            queued_at: Instant::now(),
-        });
-        
-        self.total_queued += 1;
-    }
 
-    /// Process queued uploads up to the batch size limit
-    pub fn process_uploads(
-        &mut self,
-        atlas: &mut atlas::Atlas,
-        device: &wgpu::Device,
-        encoder: &mut wgpu::CommandEncoder,
-    ) -> usize {
-        let start = Instant::now();
-        let mut processed = 0;
-        
-        // Determine the number of uploads to process in this batch
-        let pending_count = self.pending_uploads.len();
-        let count = std::cmp::min(pending_count, self.max_batch_size);
-        
-        // Process the oldest uploads first
-        for _ in 0..count {
-            if let Some(upload) = self.pending_uploads.pop_front() {
-                // Check if the allocation is valid before processing
-                let allocation_layer = upload.allocation.layer();
-                let layer_count = atlas.layer_count();
-                
-                if allocation_layer >= layer_count {
-                    log::error!("SKIPPING INVALID UPLOAD: Layer {} exceeds atlas size {}", 
-                               allocation_layer, layer_count);
-                    continue;
-                }
-                
-                // Upload to the atlas texture
-                atlas.upload_allocation(
-                    &upload.data,
-                    upload.width,
-                    upload.height,
-                    upload.padding,
-                    upload.offset,
-                    &upload.allocation,
-                    device,
-                    encoder,
-                );
-                
-                processed += 1;
-            }
-        }
-        
-        let processing_time = start.elapsed();
-        if processed > 0 {
-            // Always log for debugging
-            log::info!("Processed {}/{} texture uploads in {:.2}ms (total: {}/{})", 
-                     processed, self.pending_uploads.len() + processed,
-                     processing_time.as_secs_f64() * 1000.0,
-                     self.total_processed, self.total_queued);
-        }
-        
-        processed
-    }
-    
     /// Get number of pending uploads
     pub fn pending_count(&self) -> usize {
         self.pending_uploads.len()

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -267,7 +267,7 @@ impl StagingBuffer {
                 
                 // Get upload parameters
                 let (x, y) = upload.allocation.position();
-                let size = upload.allocation.size();
+                let size = upload.allocation.size(atlas.size());
                 
                 // Execute copy operation
                 encoder.copy_buffer_to_texture(

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -3,6 +3,125 @@ use std::time::Instant;
 
 use crate::image::atlas;
 
+use std::thread;
+use std::sync::{Arc, Mutex};
+use std::sync::mpsc::{channel, Sender, Receiver};
+use crate::image::atlas::Atlas;
+use crate::core::Size;
+
+// Background worker pool for parallel image processing
+#[derive(Debug)]
+struct ImageWorkerPool {
+    sender: Sender<ImageJob>,
+    workers: Vec<thread::JoinHandle<()>>,
+    processed_queue: Arc<Mutex<VecDeque<ProcessedImage>>>,
+}
+
+struct ImageJob {
+    data: Vec<u8>,
+    id: u64,
+    processed_queue: Arc<Mutex<VecDeque<ProcessedImage>>>,
+}
+
+#[derive(Debug)]
+struct ProcessedImage {
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+    id: u64,
+    processing_time: std::time::Duration,
+}
+
+impl ImageWorkerPool {
+    fn new(num_workers: usize) -> Self {
+        let (sender, receiver): (Sender<ImageJob>, Receiver<ImageJob>) = channel();
+        let receiver = Arc::new(Mutex::new(receiver));
+        let processed_queue = Arc::new(Mutex::new(VecDeque::new()));
+        
+        let workers = (0..num_workers).map(|i| {
+            let receiver = receiver.clone();
+            let processed_queue = processed_queue.clone();
+            
+            thread::spawn(move || {
+                log::debug!("Image worker {} started", i);
+                
+                while let Ok(job) = {
+                    let receiver = receiver.lock().unwrap();
+                    receiver.recv()
+                } {
+                    let start = Instant::now();
+                    
+                    // Actually process the image (decode, resize, etc.)
+                    let processed = Self::process_image_data(job.data);
+                    let (width, height, data) = processed;
+                    
+                    let processing_time = start.elapsed();
+                    log::trace!("Worker {} processed image {} in {:?}", 
+                              i, job.id, processing_time);
+                    
+                    // Add to processed queue
+                    if let Ok(mut queue) = job.processed_queue.lock() {
+                        queue.push_back(ProcessedImage {
+                            data,
+                            width,
+                            height,
+                            id: job.id,
+                            processing_time,
+                        });
+                    }
+                }
+                
+                log::debug!("Image worker {} stopped", i);
+            })
+        }).collect();
+        
+        Self {
+            sender,
+            workers,
+            processed_queue,
+        }
+    }
+    
+    fn process_image_data(data: Vec<u8>) -> (u32, u32, Vec<u8>) {
+        // Decode image using image crate
+        #[cfg(feature = "image")]
+        {
+            use image::GenericImageView;
+            
+            if let Ok(img) = image::load_from_memory(&data) {
+                let (width, height) = img.dimensions();
+                let rgba = img.into_rgba8();
+                return (width, height, rgba.into_raw());
+            }
+        }
+        
+        // Fallback empty image
+        (1, 1, vec![255, 0, 255, 255])
+    }
+    
+    fn submit(&self, data: Vec<u8>, id: u64) {
+        let job = ImageJob {
+            data,
+            id,
+            processed_queue: self.processed_queue.clone(),
+        };
+        
+        let _ = self.sender.send(job);
+    }
+    
+    fn get_processed(&self) -> Vec<ProcessedImage> {
+        let mut result = Vec::new();
+        
+        if let Ok(mut queue) = self.processed_queue.lock() {
+            while let Some(img) = queue.pop_front() {
+                result.push(img);
+            }
+        }
+        
+        result
+    }
+}
+
 /// A single queued texture upload
 #[derive(Debug)]
 struct PendingUpload {
@@ -22,16 +141,78 @@ pub struct StagingBuffer {
     max_batch_size: usize,
     total_queued: usize,   // Add stats tracking fields
     total_processed: usize,
+    worker_pool: ImageWorkerPool,
 }
 
 impl StagingBuffer {
     pub fn new() -> Self {
+        let num_workers = std::thread::available_parallelism()
+            .map(|n| n.get())
+            .unwrap_or(2)
+            .min(4); // Use up to 4 worker threads
+            
+        log::info!("Creating image worker pool with {} threads", num_workers);
+
         Self {
             pending_uploads: VecDeque::with_capacity(10),
             max_batch_size: 4, // Process up to 4 uploads per frame
             total_queued: 0,
             total_processed: 0,
+            worker_pool: ImageWorkerPool::new(num_workers),
         }
+    }
+
+    // Submit raw image data for parallel processing
+    pub fn submit_for_processing(&mut self, data: Vec<u8>, id: u64) {
+        self.worker_pool.submit(data, id);
+    }
+
+    // Check for processed images and queue them for upload
+    pub fn collect_processed_images(&mut self, atlas: &mut crate::image::atlas::Atlas) -> usize {
+        let processed = self.worker_pool.get_processed();
+        let count = processed.len();
+        
+        if count > 0 {
+            log::debug!("Collected {} processed images from worker threads", count);
+        }
+        
+        for img in processed {
+            // Try to allocate in the atlas
+            if let Some(entry) = atlas.allocate(img.width, img.height) {
+                // Extract allocation from Entry based on its actual structure
+                // From the Entry enum definition you shared:
+                let allocation = match entry {
+                    // If Contiguous, we can directly use the allocation
+                    atlas::entry::Entry::Contiguous(allocation) => allocation,
+                    
+                    // If Fragmented, we need to check if there are fragments and use the first one
+                    // This might not be the right approach for all cases
+                    atlas::entry::Entry::Fragmented { fragments, .. } => {
+                        if let Some(fragment) = fragments.first() {
+                            fragment.allocation.clone()
+                        } else {
+                            // No fragments available, we can't create a proper upload
+                            log::error!("Cannot upload fragmented image with no fragments");
+                            continue;
+                        }
+                    }
+                };
+                
+                let upload = PendingUpload {
+                    data: img.data,
+                    width: img.width,
+                    height: img.height,
+                    padding: 0, 
+                    offset: 0,
+                    allocation,
+                    queued_at: Instant::now(),
+                };
+                
+                self.pending_uploads.push_back(upload);
+            }
+        }
+        
+        count
     }
 
     /// Queue a texture upload to be processed during the next frame submission
@@ -123,7 +304,7 @@ impl StagingBuffer {
 
     pub fn process_uploads_parallel(
         &mut self,
-        atlas: &mut atlas::Atlas,
+        atlas: &mut crate::image::atlas::Atlas,
         device: &wgpu::Device,
         encoder: &mut wgpu::CommandEncoder,
         max_parallel: usize,
@@ -136,9 +317,13 @@ impl StagingBuffer {
         
         for _ in 0..batch_size {
             if let Some(upload) = self.pending_uploads.pop_front() {
-                // Check if allocation is valid
-                if upload.allocation.layer() >= atlas.layer_count() {
-                    log::warn!("Skipping upload to invalid layer {}", upload.allocation.layer());
+                // Check if the allocation is valid before processing
+                let allocation_layer = upload.allocation.layer();
+                let layer_count = atlas.layer_count();
+                
+                if allocation_layer >= layer_count {
+                    log::error!("SKIPPING INVALID UPLOAD: Layer {} exceeds atlas size {}", 
+                               allocation_layer, layer_count);
                     continue;
                 }
                 
@@ -155,7 +340,7 @@ impl StagingBuffer {
                 let (x, y) = upload.allocation.position();
                 let size = upload.allocation.size();
                 
-                // Execute copy operation immediately
+                // Execute copy operation
                 encoder.copy_buffer_to_texture(
                     wgpu::ImageCopyBuffer {
                         buffer: &buffer,
@@ -183,12 +368,13 @@ impl StagingBuffer {
                 );
                 
                 processed += 1;
+                self.total_processed += 1;
             }
         }
         
         if processed > 0 {
             log::debug!("Processed {} uploads in parallel in {:?}", 
-                        processed, start.elapsed());
+                      processed, start.elapsed());
         }
         
         processed

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -1,0 +1,110 @@
+use std::collections::VecDeque;
+use std::time::Instant;
+
+use crate::image::atlas;
+
+/// A single queued texture upload
+#[derive(Debug)]
+struct PendingUpload {
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+    padding: u32,
+    offset: usize,
+    allocation: atlas::Allocation,
+    queued_at: Instant,
+}
+
+/// Manages asynchronous texture uploads using staging buffers
+#[derive(Debug)]
+pub struct StagingBuffer {
+    pending_uploads: VecDeque<PendingUpload>,
+    max_batch_size: usize,
+}
+
+impl StagingBuffer {
+    pub fn new() -> Self {
+        Self {
+            pending_uploads: VecDeque::with_capacity(10),
+            max_batch_size: 4, // Process up to 4 uploads per frame
+        }
+    }
+
+    /// Queue a texture upload to be processed during the next frame submission
+    pub fn queue_upload(
+        &mut self,
+        data: &[u8],
+        width: u32,
+        height: u32,
+        padding: u32,
+        offset: usize,
+        allocation: atlas::Allocation,
+    ) {
+        self.pending_uploads.push_back(PendingUpload {
+            data: data.to_vec(), // Clone the data (could use a shared buffer in the future)
+            width,
+            height,
+            padding,
+            offset,
+            allocation,
+            queued_at: Instant::now(),
+        });
+    }
+
+    /// Process queued uploads up to the batch size limit
+    pub fn process_uploads(
+        &mut self,
+        atlas: &mut atlas::Atlas,
+        device: &wgpu::Device,
+        encoder: &mut wgpu::CommandEncoder,
+    ) -> usize {
+        let start = Instant::now();
+        let count = self.pending_uploads.len().min(self.max_batch_size);
+        
+        if count == 0 {
+            return 0;
+        }
+
+        let mut processed = 0;
+        
+        // Process the oldest uploads first
+        for _ in 0..count {
+            if let Some(upload) = self.pending_uploads.pop_front() {
+                let queue_time = upload.queued_at.elapsed();
+                
+                // Upload to the atlas texture
+                atlas.upload_allocation(
+                    &upload.data,
+                    upload.width,
+                    upload.height,
+                    upload.padding,
+                    upload.offset,
+                    &upload.allocation,
+                    device,
+                    encoder,
+                );
+                
+                processed += 1;
+                
+                // Log if uploads were queued for a long time
+                if queue_time.as_millis() > 100 {
+                    log::warn!("Texture upload queued for {}ms before processing", 
+                              queue_time.as_millis());
+                }
+            }
+        }
+        
+        let processing_time = start.elapsed();
+        if processed > 0 && processing_time.as_millis() > 5 {
+            log::debug!("Processed {} texture uploads in {:.2}ms", 
+                      processed, processing_time.as_secs_f64() * 1000.0);
+        }
+        
+        processed
+    }
+    
+    /// Get number of pending uploads
+    pub fn pending_count(&self) -> usize {
+        self.pending_uploads.len()
+    }
+}

--- a/wgpu/src/image/staging.rs
+++ b/wgpu/src/image/staging.rs
@@ -164,29 +164,29 @@ impl StagingBuffer {
 
     // Submit raw image data for parallel processing
     pub fn submit_for_processing(&mut self, data: Vec<u8>, id: u64) {
+        log::info!("Submitting image {} for parallel processing ({} bytes)", id, data.len());
         self.worker_pool.submit(data, id);
+        self.total_queued += 1;
     }
 
     // Check for processed images and queue them for upload
-    pub fn collect_processed_images(&mut self, atlas: &mut crate::image::atlas::Atlas) -> usize {
+    pub fn collect_processed_images(&mut self, atlas: &mut Atlas) -> usize {
         let processed = self.worker_pool.get_processed();
         let count = processed.len();
         
         if count > 0 {
-            log::debug!("Collected {} processed images from worker threads", count);
+            log::info!("Collected {} processed images from worker threads", count);
         }
         
         for img in processed {
             // Try to allocate in the atlas
             if let Some(entry) = atlas.allocate(img.width, img.height) {
                 // Extract allocation from Entry based on its actual structure
-                // From the Entry enum definition you shared:
                 let allocation = match entry {
                     // If Contiguous, we can directly use the allocation
                     atlas::entry::Entry::Contiguous(allocation) => allocation,
                     
                     // If Fragmented, we need to check if there are fragments and use the first one
-                    // This might not be the right approach for all cases
                     atlas::entry::Entry::Fragmented { fragments, .. } => {
                         if let Some(fragment) = fragments.first() {
                             fragment.allocation.clone()
@@ -312,10 +312,20 @@ impl StagingBuffer {
         let start = Instant::now();
         let mut processed = 0;
         
+        // First, collect any processed images from worker threads
+        let collected = self.collect_processed_images(atlas);
+        if collected > 0 {
+            log::info!("Collected {} processed images from worker threads", collected);
+        }
+        
         // Process uploads in parallel batches
         let batch_size = std::cmp::min(self.pending_uploads.len(), max_parallel);
         
-        for _ in 0..batch_size {
+        if batch_size > 0 {
+            log::info!("Processing {} image uploads in parallel", batch_size);
+        }
+        
+        for i in 0..batch_size {
             if let Some(upload) = self.pending_uploads.pop_front() {
                 // Check if the allocation is valid before processing
                 let allocation_layer = upload.allocation.layer();
@@ -331,7 +341,7 @@ impl StagingBuffer {
                 use wgpu::util::DeviceExt;
                 
                 let buffer = device.create_buffer_init(&wgpu::util::BufferInitDescriptor {
-                    label: Some("parallel image upload buffer"),
+                    label: Some(&format!("parallel image upload buffer {}", i)),
                     contents: &upload.data,
                     usage: wgpu::BufferUsages::COPY_SRC,
                 });
@@ -373,7 +383,7 @@ impl StagingBuffer {
         }
         
         if processed > 0 {
-            log::debug!("Processed {} uploads in parallel in {:?}", 
+            log::info!("Processed {} uploads in parallel in {:?}", 
                       processed, start.elapsed());
         }
         

--- a/wgpu/src/image/upload_worker.rs
+++ b/wgpu/src/image/upload_worker.rs
@@ -1,0 +1,62 @@
+use std::sync::{Arc, Mutex};
+use std::thread;
+use std::sync::mpsc::{channel, Sender, Receiver};
+
+pub struct UploadWorker {
+    sender: Sender<UploadJob>,
+    _worker_thread: thread::JoinHandle<()>,
+}
+
+struct UploadJob {
+    data: Vec<u8>,
+    width: u32,
+    height: u32,
+    handle_id: u64,
+    callback: Arc<Mutex<dyn FnMut(u64, Vec<u8>) + Send + 'static>>,
+}
+
+impl UploadWorker {
+    pub fn new() -> Self {
+        let (sender, receiver) = channel();
+        
+        let worker_thread = thread::spawn(move || {
+            Self::worker_loop(receiver);
+        });
+        
+        Self {
+            sender,
+            _worker_thread: worker_thread,
+        }
+    }
+    
+    fn worker_loop(receiver: Receiver<UploadJob>) {
+        while let Ok(job) = receiver.recv() {
+            // Process the image data on a background thread
+            // This could include resizing, format conversion, etc.
+            
+            // When finished, notify through the callback
+            if let Ok(mut callback) = job.callback.lock() {
+                callback(job.handle_id, job.data);
+            }
+        }
+    }
+    
+    pub fn queue_upload(
+        &self,
+        data: Vec<u8>,
+        width: u32,
+        height: u32,
+        handle_id: u64,
+        callback: Arc<Mutex<dyn FnMut(u64, Vec<u8>) + Send + 'static>>,
+    ) {
+        let job = UploadJob {
+            data,
+            width,
+            height,
+            handle_id,
+            callback,
+        };
+        
+        let _ = self.sender.send(job);
+    }
+}

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -654,3 +654,10 @@ pub fn get_image_rendering_diagnostics() -> (f64, f64, f64, f64, f64, usize) {
 pub fn log_image_rendering_stats() {
     let _ = image::get_image_rendering_stats_with_logging();
 }
+
+
+/// Display debug information about image upload status
+#[cfg(any(feature = "image", feature = "svg"))]
+pub fn debug_image_upload_status() {
+    image::debug_image_upload_status()
+}

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -638,3 +638,19 @@ pub fn get_image_rendering_stats() -> (f64, f64, f64) {
     }
     (0.0, 0.0, 0.0)
 }
+
+/// Get comprehensive image rendering diagnostics
+pub fn get_image_rendering_diagnostics() -> (f64, f64, f64, f64, f64, usize) {
+    if let Ok(tracker) = image::IMAGE_DISPLAY_TRACKER.lock() {
+        let (fps, avg_upload, avg_render, min_render, max_render) = 
+            tracker.get_detailed_timing_stats();
+        let frame_count = tracker.total_frames_rendered;
+        return (fps, avg_upload, avg_render, min_render, max_render, frame_count);
+    }
+    (0.0, 0.0, 0.0, 0.0, 0.0, 0)
+}
+
+/// Log current image rendering performance stats
+pub fn log_image_rendering_stats() {
+    let _ = image::get_image_rendering_stats_with_logging();
+}

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -628,3 +628,13 @@ pub fn get_image_upload_timestamps() -> std::collections::VecDeque<std::time::In
 pub fn sync_image_tracker_timestamps(timestamps: std::collections::VecDeque<std::time::Instant>) {
     image::sync_image_tracker_timestamps(timestamps)
 }
+
+/// Get detailed image rendering performance stats
+pub fn get_image_rendering_stats() -> (f64, f64, f64) {
+    if let Ok(tracker) = image::IMAGE_DISPLAY_TRACKER.lock() {
+        let fps = tracker.get_fps();
+        let (avg_upload, avg_render) = tracker.get_timing_stats();
+        return (fps, avg_upload, avg_render);
+    }
+    (0.0, 0.0, 0.0)
+}

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -630,6 +630,7 @@ pub fn sync_image_tracker_timestamps(timestamps: std::collections::VecDeque<std:
 }
 
 /// Get detailed image rendering performance stats
+#[cfg(any(feature = "image", feature = "svg"))]
 pub fn get_image_rendering_stats() -> (f64, f64, f64) {
     if let Ok(tracker) = image::IMAGE_DISPLAY_TRACKER.lock() {
         let fps = tracker.get_fps();
@@ -640,6 +641,7 @@ pub fn get_image_rendering_stats() -> (f64, f64, f64) {
 }
 
 /// Get comprehensive image rendering diagnostics
+#[cfg(any(feature = "image", feature = "svg"))]
 pub fn get_image_rendering_diagnostics() -> (f64, f64, f64, f64, f64, usize) {
     if let Ok(tracker) = image::IMAGE_DISPLAY_TRACKER.lock() {
         let (fps, avg_upload, avg_render, min_render, max_render) = 
@@ -651,6 +653,7 @@ pub fn get_image_rendering_diagnostics() -> (f64, f64, f64, f64, f64, usize) {
 }
 
 /// Log current image rendering performance stats
+#[cfg(any(feature = "image", feature = "svg"))]
 pub fn log_image_rendering_stats() {
     let _ = image::get_image_rendering_stats_with_logging();
 }

--- a/wgpu/src/lib.rs
+++ b/wgpu/src/lib.rs
@@ -32,7 +32,7 @@ pub mod geometry;
 
 mod buffer;
 mod color;
-mod engine;
+pub mod engine;
 mod quad;
 mod text;
 mod triangle;

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -6,7 +6,10 @@ use crate::graphics::error;
 use crate::graphics::{self, Viewport};
 use crate::settings::{self, Settings};
 use crate::{Engine, Renderer};
+
+#[cfg(feature = "image")]
 use crate::engine::ImageConfig;
+
 /// A window graphics backend for iced powered by `wgpu`.
 #[allow(missing_debug_implementations)]
 pub struct Compositor {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -169,6 +169,7 @@ impl Compositor {
 
             match result {
                 Ok((device, queue)) => {
+                    #[cfg(feature = "image")]
                     let engine = Engine::new(
                         &adapter,
                         &device,
@@ -176,6 +177,15 @@ impl Compositor {
                         format,
                         settings.antialiasing,
                         Some(ImageConfig::default()),
+                    );
+                    #[cfg(not(feature = "image"))]
+                    let engine = Engine::new(
+                        &adapter,
+                        &device,
+                        &queue,
+                        format,
+                        settings.antialiasing,
+                        None,
                     );
 
                     return Ok(Compositor {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -6,7 +6,7 @@ use crate::graphics::error;
 use crate::graphics::{self, Viewport};
 use crate::settings::{self, Settings};
 use crate::{Engine, Renderer};
-
+use crate::engine::ImageConfig;
 /// A window graphics backend for iced powered by `wgpu`.
 #[allow(missing_debug_implementations)]
 pub struct Compositor {
@@ -175,6 +175,9 @@ impl Compositor {
                         &queue,
                         format,
                         settings.antialiasing,
+                        Some(ImageConfig {
+                            use_parallel_processing: false,
+                        }),
                     );
 
                     return Ok(Compositor {

--- a/wgpu/src/window/compositor.rs
+++ b/wgpu/src/window/compositor.rs
@@ -175,9 +175,7 @@ impl Compositor {
                         &queue,
                         format,
                         settings.antialiasing,
-                        Some(ImageConfig {
-                            use_parallel_processing: false,
-                        }),
+                        Some(ImageConfig::default()),
                     );
 
                     return Ok(Compositor {


### PR DESCRIPTION
- Add a new `ImageConfig` struct to enable parallel texture uploads and configure atlas size
- Implements StagingBuffer and ImageWorkerPool for async image decoding
- Add `Cache::upload()` to choose between sync and parallel uploads automatically
- Add additional diagnostic helpers `ImageDisplayTracker` and image/mod.rs
- Refactor iced_wgpu modules to be compatible with the new pipeline