### PR TITLE
Update winit to partial crash fix branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,9 +186,8 @@ winapi = "0.3"
 window_clipboard = "0.4.1"
 #winit = "0.30"
 # v0.30.0 mac+windows custom dependencies
-#winit = { git = "https://github.com/ggand0/winit.git", rev = "ef40f477b66b64f68eda0562a92bd42bcd35b14a" }
-winit = { git = "https://github.com/ggand0/winit.git", rev = "e6ca302116d7f5c6c212cf659db63fabed9afbe5" }
-#winit = { git = "https://github.com/rust-windowing/winit.git", branch = "master" }
+# + 0.30.1 partial fix for macOS
+winit = { git = "https://github.com/ggand0/winit.git", rev = "4118fd4396cf3cf29655668e9197fa657c598805" } # 0.30.0-15
 rayon = "1.8"
 texpresso = { version = "2.0.1", features = ["rayon"] }
 


### PR DESCRIPTION
Update Cargo.toml to use the experimental winit branch that applies the macOS crash fix from upstream 0.30.1 without adopting event queueing changes.